### PR TITLE
frontend: include cookies for /-/debug/headers

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -82,7 +82,6 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 	r.Get(router.Editor).Handler(trace.Route(errorutil.Handler(serveEditor(db))))
 
 	r.Get(router.DebugHeaders).Handler(trace.Route(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Del("Cookie")
 		_ = r.Header.Write(w)
 	})))
 	addDebugHandlers(r.Get(router.Debug).Subrouter(), db)


### PR DESCRIPTION
We have the useful debug endpoint which just echos back the headers we received. For example view https://sourcegraph.com/-/debug/headers

This is very useful for debugging issues around auth proxies/etc. We explicitly excluded cookies. This dates back to the original introduction of this endpoint many years ago, and the PR has no context why. Recently a customer would of found this field useful when debugging an internal proxy they use (in particular debugging how it interacted with bitbucket webhooking into sourcegraph).

Test Plan: visit /-/debug/headers

Fixes https://github.com/sourcegraph/sourcegraph/issues/37873
