### PR TITLE
fix: set webRoot to /client/web in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,7 @@
       "type": "chrome",
       "request": "attach",
       "port": 9222,
-      "webRoot": "${workspaceRoot}/web",
+      "webRoot": "${workspaceRoot}/client/web",
       "url": "http://localhost:3080/*",
       "sourceMaps": true
     },


### PR DESCRIPTION
When debugging in 'Webapp Chrome' mode, breakpoints are be left unbound because of the misconfigured `"webRoot"` (source maps were not loaded correctly).

I am using VSCode **Version: 1.80.2 (Universal)**. Not sure if it's an issue with my local setup or if anyone else is experiencing this as well.

## Test plan

To reproduce:
- Follow instructions for [debugging TypeScript code](https://docs.sourcegraph.com/dev/how-to/debug_live_code#debug-typescript-code)
- Set breakpoint in any file (e.g. `client/web/src/repo/RepoRevisionSidebarSymbolTree.tsx`)
- See the "Unbound breakpoint" popup

After setting `webRoot` to `${workspaceRoot}/client/web}` the breakpoints get bound/activated.