### PR TITLE
Unconditionally runs the `n auto` command for TS indexing

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -40,6 +40,8 @@ local infer_typescript_job = function(api, tsconfig_path, should_infer_config)
 
   api:register(recognizer.new_path_recognizer {
     patterns = {
+      -- To find package roots
+      pattern.new_path_basename "package.json",
       -- To disambiguate installation steps
       pattern.new_path_basename "yarn.lock",
       -- Try to determine version
@@ -48,7 +50,6 @@ local infer_typescript_job = function(api, tsconfig_path, should_infer_config)
       pattern.new_path_basename ".nvmrc",
       -- To reinvoke simple cases with no other files
       pattern.new_path_basename "tsconfig.json",
-      pattern.new_path_basename "package.json",
       pattern.new_path_exclude(exclude_paths),
     },
 

--- a/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_1.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_1.yaml
@@ -2,8 +2,10 @@
     - root: ""
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - npm install --ignore-scripts
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8

--- a/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_2.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_2.yaml
@@ -2,8 +2,10 @@
     - root: ""
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - yarn --ignore-scripts
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8

--- a/internal/codeintel/autoindexing/internal/inference/testdata/simple_tsconfig.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/simple_tsconfig.yaml
@@ -1,5 +1,6 @@
 - steps: []
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8

--- a/internal/codeintel/autoindexing/internal/inference/testdata/tsconfig_in_subdirectories.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/tsconfig_in_subdirectories.yaml
@@ -1,5 +1,6 @@
 - steps: []
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: a
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
@@ -11,6 +12,7 @@
     - NPM_TOKEN
 - steps: []
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: b
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
@@ -22,6 +24,7 @@
     - NPM_TOKEN
 - steps: []
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: c
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8

--- a/internal/codeintel/autoindexing/internal/inference/testdata/typescript_installation_steps.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/typescript_installation_steps.yaml
@@ -2,8 +2,10 @@
     - root: ""
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - npm install
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
@@ -17,12 +19,15 @@
     - root: ""
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - npm install
     - root: foo/bar
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - yarn
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: foo/bar/baz
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
@@ -36,16 +41,20 @@
     - root: ""
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - npm install
     - root: foo/bar
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - yarn
     - root: foo/bar/bonk
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - npm install
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: foo/bar/bonk
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
@@ -59,8 +68,10 @@
     - root: ""
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - npm install
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: foo/baz
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8

--- a/internal/codeintel/autoindexing/internal/inference/testdata/typescript_with_lerna_configuration.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/typescript_with_lerna_configuration.yaml
@@ -2,8 +2,10 @@
     - root: ""
       image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
+        - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - yarn
   local_steps:
+    - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8


### PR DESCRIPTION
This fixes inference failures against repos with a large number of package.json files, by reading the content of fewer files.

## Test plan

Still figuring this out