### PR TITLE
Disable update.channel site configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search Jobs switches the format of downloaded results from CSV to JSON. [#59619](https://github.com/sourcegraph/sourcegraph/pull/59619)
 - [Search Jobs](https://docs.sourcegraph.com/code_search/how-to/search-jobs) is now in beta and enabled by default. It can be disabled in the site configuration by setting `experimentalFeatures.searchJobs: false`.
 - The search input on the search homepage is now automatically focused when the page loads.
+- The site config setting `update.channel` has been deprecated and is not longer having an effect. Previously, overwriting the update channel with anything other than `release` would have disabled the update check and sending pings data along with it. Now, instances with a license that allows air gapped usage will NOT send those pings instead.
 
 ### Fixed
 

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -64,9 +64,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         searchAggregationEnabled: true,
         searchContextsEnabled: true,
         sentryDSN: null,
-        site: {
-            'update.channel': 'release',
-        },
+        site: {},
         siteID: 'TestSiteID',
         siteGQLID: 'TestGQLSiteID',
         sourcegraphDotComMode: ENVIRONMENT_CONFIG.SOURCEGRAPHDOTCOM_MODE,

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -144,7 +144,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /**
      * A subset of the site configuration. Not all fields are set.
      */
-    site: Pick<SiteConfiguration, 'auth.public' | 'update.channel' | 'authz.enforceForSiteAdmins'>
+    site: Pick<SiteConfiguration, 'authz.enforceForSiteAdmins' | 'disableNonCriticalTelemetry'>
 
     /** Whether access tokens are enabled. */
     accessTokensAllow: 'all-users-create' | 'site-admin-create' | 'none'
@@ -322,4 +322,5 @@ export interface BrandAssets {
 export interface LicenseFeatures {
     codeSearch: boolean
     cody: boolean
+    allowAirGapped: boolean
 }

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -44,7 +44,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
         eventLogger.logViewEvent('SiteAdminPings')
     }, [])
 
-    const updatesDisabled = window.context.site['update.channel'] !== 'release'
+    const updatesDisabled = window.context.licenseInfo?.features.allowAirGapped ?? false
     const jsonEditorContainerRef = useRef<HTMLDivElement | null>(null)
     const editorRef = useRef<EditorView | null>(null)
 

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -22,7 +22,6 @@ import {
     PageHeader,
     Alert,
     Icon,
-    Code,
     Container,
     Text,
     ErrorAlert,
@@ -48,7 +47,7 @@ const capitalize = (text: string): string => (text && text[0].toUpperCase() + te
 
 const SiteUpdateCheck: React.FC = () => {
     const { data, loading, error } = useQuery<SiteUpdateCheckResult, SiteUpdateCheckVariables>(SITE_UPDATE_CHECK, {})
-    const autoUpdateCheckingEnabled = window.context.site['update.channel'] === 'release'
+    const autoUpdateCheckingEnabled = window.context.licenseInfo?.features.allowAirGapped ?? false
 
     return (
         <>
@@ -123,9 +122,7 @@ const SiteUpdateCheck: React.FC = () => {
             <small>
                 {autoUpdateCheckingEnabled
                     ? 'Automatically checking for updates.'
-                    : 'Automatic checking for updates disabled.'}{' '}
-                Change <Code>update.channel</Code> in <Link to="/site-admin/configuration">site configuration</Link> to{' '}
-                {autoUpdateCheckingEnabled ? 'disable' : 'enable'} automatic checking.
+                    : 'Automatic checking for updates disabled.'}
             </small>
         </>
     )

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -22,8 +22,9 @@ type FeatureBatchChanges struct {
 // LicenseFeatures contains information about licensed features that are
 // enabled/disabled on the current license.
 type LicenseFeatures struct {
-	CodeSearch bool `json:"codeSearch"`
-	Cody       bool `json:"cody"`
+	CodeSearch     bool `json:"codeSearch"`
+	Cody           bool `json:"cody"`
+	AllowAirGapped bool `json:"allowAirGapped"`
 }
 
 // LicenseInfo contains non-sensitive information about the legitimate usage of the

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -606,8 +606,6 @@ func resolveLatestSettings(ctx context.Context, user *graphqlbackend.UserResolve
 func publicSiteConfiguration() schema.SiteConfiguration {
 	c := conf.Get()
 	return schema.SiteConfiguration{
-		AuthPublic:                  c.AuthPublic,
-		UpdateChannel:               conf.UpdateChannel(),
 		AuthzEnforceForSiteAdmins:   c.AuthzEnforceForSiteAdmins,
 		DisableNonCriticalTelemetry: c.DisableNonCriticalTelemetry,
 	}

--- a/cmd/frontend/internal/licensing/init/init.go
+++ b/cmd/frontend/internal/licensing/init/init.go
@@ -110,8 +110,9 @@ func Init(
 		}
 
 		licenseInfo.Features = hooks.LicenseFeatures{
-			CodeSearch: licensing.Check(licensing.FeatureCodeSearch) == nil,
-			Cody:       licensing.Check(licensing.FeatureCody) == nil,
+			CodeSearch:     licensing.Check(licensing.FeatureCodeSearch) == nil,
+			Cody:           licensing.Check(licensing.FeatureCody) == nil,
+			AllowAirGapped: licensing.Check(licensing.FeatureAllowAirGapped) == nil,
 		}
 
 		return licenseInfo

--- a/dev/site-config.json
+++ b/dev/site-config.json
@@ -7,7 +7,6 @@
     }
   ],
   "externalURL": "http://localhost:3080/",
-  "update.channel": "release",
   "experimentalFeatures": {},
   "repoListUpdateInterval": 1
 }

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -261,6 +261,7 @@ The most common scenario in which Sourcegraph stops sending pings is a change to
 ```
 *This setting [must be set to "release"](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/updatecheck/client.go?L803-806) in order for the telemetry goroutine to run.*
 
+> Note: This setting has been deprecated in Sourcegraph 5.3 and is no longer active.
 
 ### Check if the goroutine is running
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -153,15 +153,6 @@ func EmailSenderName() string {
 	return "Sourcegraph"
 }
 
-// UpdateChannel tells the update channel. Default is "release".
-func UpdateChannel() string {
-	channel := Get().UpdateChannel
-	if channel == "" {
-		return "release"
-	}
-	return channel
-}
-
 func BatchChangesEnabled() bool {
 	if enabled := Get().BatchChangesEnabled; enabled != nil {
 		return *enabled

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -521,7 +521,6 @@ func getTestSiteWithSecrets(testSecrets testSecrets, optionalEdit ...string) str
   "email.address": "%s",
   "executors.accessToken": "%s",
   "externalURL": "https://sourcegraph.test:3443",
-  "update.channel": "release",
   "auth.providers": [
     {
       "allowSignup": true,

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2420,6 +2420,7 @@
       "default": 3
     },
     "update.channel": {
+      "deprecationMessage": "Deprecated. No alternative channels exist.",
       "description": "The channel on which to automatically check for Sourcegraph updates.",
       "type": ["string"],
       "enum": ["release", "none"],


### PR DESCRIPTION
Instead, we rely on the AllowAirGapped license feature to turn off update checks and thus pings.

This makes it so that we never accidentally send pings when the customer intends to be air gapped.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@es/release-no-disable)