### PR TITLE
gitserver: Fix infinite clone loop for repo duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Selecting "View blame prior to this change" on a file that was moved will now correctly navigate to the old file location at the specified commit. [#61577](https://github.com/sourcegraph/sourcegraph/pull/61577)
 - Git blame performance on large files with a large number of commits has been drastically improved. [#61577](https://github.com/sourcegraph/sourcegraph/pull/61577)
 - Code Insights now properly ignores search API alerts, which previously would have led to a code insight error. [#61431](https://github.com/sourcegraph/sourcegraph/pull/61431)
+- Fixed an issue that could cause repositories to be recloned indefinitely when a repo has been deleted on a codehost and recreated under the same name. [#60643](https://github.com/sourcegraph/sourcegraph/pull/60643)
 
 ## 5.3.3
 

--- a/cmd/gitserver/internal/statesyncer.go
+++ b/cmd/gitserver/internal/statesyncer.go
@@ -175,8 +175,6 @@ func syncRepoState(
 	}
 
 	options := database.IterateRepoGitserverStatusOptions{
-		// We also want to include deleted repos as they may still be cloned on disk
-		IncludeDeleted:   true,
 		BatchSize:        iteratePageSize,
 		OnlyWithoutShard: !fullSync,
 	}

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -245,19 +245,12 @@ ORDER BY deleted_at ASC
 type IterateRepoGitserverStatusOptions struct {
 	// If set, will only iterate over repos that have not been assigned to a shard
 	OnlyWithoutShard bool
-	// If true, also include deleted repos. Note that their repo name will start with
-	// 'DELETED-'
-	IncludeDeleted bool
-	BatchSize      int
-	NextCursor     int
+	BatchSize        int
+	NextCursor       int
 }
 
 func (s *gitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions) (rs []types.RepoGitserverStatus, nextCursor int, err error) {
 	preds := []*sqlf.Query{}
-
-	if !options.IncludeDeleted {
-		preds = append(preds, sqlf.Sprintf("repo.deleted_at IS NULL"))
-	}
 
 	if options.OnlyWithoutShard {
 		preds = append(preds, sqlf.Sprintf("gr.shard_id = ''"))

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -47,6 +47,9 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// And reinsert a repo with the same name (the case where a repo is deleted and recreated so the external ID changes)
+	require.NoError(t, db.Repos().Create(ctx, &types.Repo{Name: "github.com/sourcegraph/repo3"}))
+
 	if err := db.GitserverRepos().Update(ctx, &types.GitserverRepo{
 		RepoID:      repos[0].ID,
 		ShardID:     "shard-0",
@@ -96,13 +99,13 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	}
 
 	t.Run("iterate with default options", func(t *testing.T) {
-		assert(t, 2, 2, IterateRepoGitserverStatusOptions{})
+		assert(t, 3, 3, IterateRepoGitserverStatusOptions{})
 	})
 	t.Run("iterate only repos without shard", func(t *testing.T) {
-		assert(t, 1, 1, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true})
+		assert(t, 2, 2, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true})
 	})
 	t.Run("include deleted", func(t *testing.T) {
-		assert(t, 3, 3, IterateRepoGitserverStatusOptions{IncludeDeleted: true})
+		assert(t, 3, 3, IterateRepoGitserverStatusOptions{IncludeDeleted: true}) // Note that we still only get 3 repos here, not 4, because for the one deleted repo there exists a second repo that has the same name.
 	})
 	t.Run("include deleted, but still only without shard", func(t *testing.T) {
 		assert(t, 2, 2, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true, IncludeDeleted: true})

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -104,12 +104,6 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	t.Run("iterate only repos without shard", func(t *testing.T) {
 		assert(t, 2, 2, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true})
 	})
-	t.Run("include deleted", func(t *testing.T) {
-		assert(t, 3, 3, IterateRepoGitserverStatusOptions{IncludeDeleted: true}) // Note that we still only get 3 repos here, not 4, because for the one deleted repo there exists a second repo that has the same name.
-	})
-	t.Run("include deleted, but still only without shard", func(t *testing.T) {
-		assert(t, 2, 2, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true, IncludeDeleted: true})
-	})
 }
 
 func TestListPurgeableRepos(t *testing.T) {


### PR DESCRIPTION
This is admittedly a bit of a hack, but this cost us thousands of dollars on cloud before so I don't feel too terrible about this. The real solution will require to track repos by an actually unique identifier that is immutable, but that's much more work.

After the various fixes made to repo name normalization, there's less instances of "accidentally updating the wrong DB entry". In fact, after the previous PR everything already works alright. Except on a restart, where gitserver scans all repos and updates their clone status.

To work around this, we now exclude repos from state updates in the initial run that have another undeleted repo with the same name.

This is not a complete solution, but addresses all the happy path cases I could find where a repo was incorrectly recloned.

Closes #55545 

## Test plan

Recreated the scenario where repo A is deleted, and repo B has taken the name of repo A in the database. On main, we regularly delete this repo and reclone it. On this branch, this doesn't happen. Also adjusted tests for the store method.
