### PR TITLE
gitserver: Fetch in GitBackend

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/fetch.go
+++ b/cmd/gitserver/internal/git/gitcli/fetch.go
@@ -1,0 +1,177 @@
+package gitcli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/urlredactor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func (g *gitCLIBackend) Fetch(ctx context.Context, opt git.FetchOptions) (git.RefUpdateIterator, io.Reader, error) {
+	redactor := urlredactor.New(opt.RemoteURL)
+
+	args, env := buildFetchArgs(opt)
+	// see issue #7322: skip LFS content in repositories with Git LFS configured.
+	env = append(env, "GIT_LFS_SKIP_SMUDGE=1")
+
+	stderrR, stderrW := io.Pipe()
+	r, err := g.NewCommand(ctx,
+		WithArguments(args...),
+		WithEnv(env...),
+		WithOutputRedactor(redactor.Redact),
+		WithStderr(stderrW),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &refUpdateIterator{
+		stdout: r,
+		onCancel: func() error {
+			return errors.Append(stderrR.Close(), stderrW.Close())
+		},
+		sc: bufio.NewScanner(r),
+	}, stderrR, nil
+}
+
+type refUpdateIterator struct {
+	stdout   io.ReadCloser
+	sc       *bufio.Scanner
+	onCancel func() error
+}
+
+func (i *refUpdateIterator) Next() (git.RefUpdate, error) {
+	for i.sc.Scan() {
+		if len(i.sc.Bytes()) == 0 {
+			continue
+		}
+		return parseRefUpdateLine(i.sc.Bytes())
+	}
+
+	if err := i.sc.Err(); err != nil {
+		return git.RefUpdate{}, err
+	}
+
+	return git.RefUpdate{}, io.EOF
+}
+
+func (i *refUpdateIterator) Close() error {
+	cancelErr := i.onCancel()
+	err := i.stdout.Close()
+	if cancelErr != nil {
+		err = errors.Append(err, cancelErr)
+	}
+	return err
+}
+
+func buildFetchArgs(opt git.FetchOptions) (args, env []string) {
+	env = []string{
+		// disable password prompt
+		"GIT_ASKPASS=true",
+		// Suppress asking to add SSH host key to known_hosts (which will hang because
+		// the command is non-interactive).
+		//
+		// And set a timeout to avoid indefinite hangs if the server is unreachable.
+		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30",
+		// Identify HTTP requests with a user agent. Please keep the git/ prefix because GitHub breaks the protocol v2
+		// negotiation of clone URLs without a `.git` suffix (which we use) without it. Don't ask.
+		"GIT_HTTP_USER_AGENT=git/Sourcegraph-Bot",
+	}
+
+	if opt.TLSConfig.SSLNoVerify {
+		env = append(env, "GIT_SSL_NO_VERIFY=true")
+	}
+	if opt.TLSConfig.SSLCAInfo != "" {
+		env = append(env, "GIT_SSL_CAINFO="+opt.TLSConfig.SSLCAInfo)
+	}
+
+	// If we have creds in the URL, pass them in via the credHelper instead of
+	// as part of the URL, because args are visible in `ps` output, leaking the
+	// credentials easily.
+	remoteURLArg := opt.RemoteURL.String()
+	credentialHelper := []string{}
+	password, ok := opt.RemoteURL.User.Password()
+	if ok && !opt.RemoteURL.IsSSH() {
+		// Remove the user section from the remoteURL so that git consults credential
+		// helpers for the username/password.
+		ru := *opt.RemoteURL
+		ru.User = nil
+		remoteURLArg = ru.String()
+
+		// Next up, add out credential helper.
+		// Note: We add an ADDITIONAL credential helper here, the previous
+		// one is just unsetting any existing ones.
+		credentialHelper = []string{"-c", "credential.helper=!f() { echo \"username=$GIT_SG_USERNAME\npassword=$GIT_SG_PASSWORD\"; }; f"}
+		env = append(env,
+			"GIT_SG_USERNAME="+opt.RemoteURL.User.Username(),
+			"GIT_SG_PASSWORD="+password,
+		)
+	}
+
+	args = []string{
+		// Unset credential helper because the command is non-interactive.
+		// Even when we pass a second credential helper for HTTP credentials,
+		// we will need this. Otherwise, the original credential helper will be used
+		// as well.
+		"-c", "credential.helper=",
+	}
+	args = append(args, credentialHelper...)
+	args = append(args,
+		"-c", "protocol.version=2",
+		"fetch",
+		"--progress",
+		"--prune",
+		"--porcelain",
+		remoteURLArg,
+	)
+
+	return args, env
+}
+
+func parseRefUpdateLine(line []byte) (u git.RefUpdate, _ error) {
+	line = bytes.TrimSpace(line)
+	// format:
+	// <flag> <old-object-id> <new-object-id> <local-reference>
+	if len(line) == 0 {
+		return git.RefUpdate{}, errors.New("empty git ref update output")
+	}
+	if line[0] == ' ' {
+		u.Type = git.RefUpdateTypeFastForwardUpdate
+		line[0] = 'x'
+	}
+	parts := bytes.Fields(line)
+	if len(parts) != 4 {
+		return git.RefUpdate{}, errors.Newf("invalid ref update format, expected exactly 4 fields %q", line)
+	}
+
+	if line[0] != 'x' {
+		switch git.RefUpdateType(line[0]) {
+		case git.RefUpdateTypeFastForwardUpdate:
+			u.Type = git.RefUpdateTypeFastForwardUpdate
+		case git.RefUpdateTypeForcedUpdate:
+			u.Type = git.RefUpdateTypeForcedUpdate
+		case git.RefUpdateTypePruned:
+			u.Type = git.RefUpdateTypePruned
+		case git.RefUpdateTypeTagUpdate:
+			u.Type = git.RefUpdateTypeTagUpdate
+		case git.RefUpdateTypeNewRef:
+			u.Type = git.RefUpdateTypeNewRef
+		case git.RefUpdateTypeFailed:
+			u.Type = git.RefUpdateTypeFailed
+		case git.RefUpdateTypeUnchanged:
+			u.Type = git.RefUpdateTypeUnchanged
+		default:
+			return git.RefUpdate{}, errors.Newf("invalid ref update type %q", line[0])
+		}
+	}
+	u.OldSHA = api.CommitID(parts[1])
+	u.NewSHA = api.CommitID(parts[2])
+	u.LocalReference = string(parts[3])
+
+	return u, nil
+}

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -1142,7 +1142,7 @@ func TestServer_IsRepoCloneable_InternalActor(t *testing.T) {
 type mockVCSSyncer struct {
 	mockTypeFunc    func() string
 	mockIsCloneable func(ctx context.Context, repoName api.RepoName) error
-	mockClone       func(ctx context.Context, repo api.RepoName, targetDir common.GitDir, tmpPath string, progressWriter io.Writer) error
+	mockClone       func(ctx context.Context, repo api.RepoName, tmpPath string, progressWriter io.Writer) error
 	mockFetch       func(ctx context.Context, repoName api.RepoName, dir common.GitDir, progressWriter io.Writer) error
 }
 
@@ -1162,9 +1162,9 @@ func (m *mockVCSSyncer) IsCloneable(ctx context.Context, repoName api.RepoName) 
 	return errors.New("no mock for IsCloneable() is set")
 }
 
-func (m *mockVCSSyncer) Clone(ctx context.Context, repo api.RepoName, targetDir common.GitDir, tmpPath string, progressWriter io.Writer) error {
+func (m *mockVCSSyncer) Clone(ctx context.Context, repo api.RepoName, tmpPath string, progressWriter io.Writer) error {
 	if m.mockClone != nil {
-		return m.mockClone(ctx, repo, targetDir, tmpPath, progressWriter)
+		return m.mockClone(ctx, repo, tmpPath, progressWriter)
 	}
 
 	return errors.New("no mock for Clone() is set")

--- a/cmd/gitserver/internal/vcssyncer/instrumented_syncer.go
+++ b/cmd/gitserver/internal/vcssyncer/instrumented_syncer.go
@@ -80,9 +80,9 @@ func (i *instrumentedSyncer) IsCloneable(ctx context.Context, repoName api.RepoN
 	return i.base.IsCloneable(ctx, repoName)
 }
 
-func (i *instrumentedSyncer) Clone(ctx context.Context, repo api.RepoName, targetDir common.GitDir, tmpPath string, progressWriter io.Writer) (err error) {
+func (i *instrumentedSyncer) Clone(ctx context.Context, repo api.RepoName, tmpPath string, progressWriter io.Writer) (err error) {
 	if !i.shouldObserve() {
-		return i.base.Clone(ctx, repo, targetDir, tmpPath, progressWriter)
+		return i.base.Clone(ctx, repo, tmpPath, progressWriter)
 	}
 
 	start := time.Now()
@@ -93,7 +93,7 @@ func (i *instrumentedSyncer) Clone(ctx context.Context, repo api.RepoName, targe
 		metricCloneDuration.WithLabelValues(i.formattedTypeLabel, strconv.FormatBool(succeeded)).Observe(duration)
 	}()
 
-	return i.base.Clone(ctx, repo, targetDir, tmpPath, progressWriter)
+	return i.base.Clone(ctx, repo, tmpPath, progressWriter)
 }
 
 func (i *instrumentedSyncer) Fetch(ctx context.Context, repoName api.RepoName, dir common.GitDir, progressWriter io.Writer) (err error) {

--- a/cmd/gitserver/internal/vcssyncer/mock.go
+++ b/cmd/gitserver/internal/vcssyncer/mock.go
@@ -39,7 +39,7 @@ type MockVCSSyncer struct {
 func NewMockVCSSyncer() *MockVCSSyncer {
 	return &MockVCSSyncer{
 		CloneFunc: &VCSSyncerCloneFunc{
-			defaultHook: func(context.Context, api.RepoName, common.GitDir, string, io.Writer) (r0 error) {
+			defaultHook: func(context.Context, api.RepoName, string, io.Writer) (r0 error) {
 				return
 			},
 		},
@@ -66,7 +66,7 @@ func NewMockVCSSyncer() *MockVCSSyncer {
 func NewStrictMockVCSSyncer() *MockVCSSyncer {
 	return &MockVCSSyncer{
 		CloneFunc: &VCSSyncerCloneFunc{
-			defaultHook: func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error {
+			defaultHook: func(context.Context, api.RepoName, string, io.Writer) error {
 				panic("unexpected invocation of MockVCSSyncer.Clone")
 			},
 		},
@@ -110,23 +110,23 @@ func NewMockVCSSyncerFrom(i VCSSyncer) *MockVCSSyncer {
 // VCSSyncerCloneFunc describes the behavior when the Clone method of the
 // parent MockVCSSyncer instance is invoked.
 type VCSSyncerCloneFunc struct {
-	defaultHook func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error
-	hooks       []func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error
+	defaultHook func(context.Context, api.RepoName, string, io.Writer) error
+	hooks       []func(context.Context, api.RepoName, string, io.Writer) error
 	history     []VCSSyncerCloneFuncCall
 	mutex       sync.Mutex
 }
 
 // Clone delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockVCSSyncer) Clone(v0 context.Context, v1 api.RepoName, v2 common.GitDir, v3 string, v4 io.Writer) error {
-	r0 := m.CloneFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.CloneFunc.appendCall(VCSSyncerCloneFuncCall{v0, v1, v2, v3, v4, r0})
+func (m *MockVCSSyncer) Clone(v0 context.Context, v1 api.RepoName, v2 string, v3 io.Writer) error {
+	r0 := m.CloneFunc.nextHook()(v0, v1, v2, v3)
+	m.CloneFunc.appendCall(VCSSyncerCloneFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the Clone method of the
 // parent MockVCSSyncer instance is invoked and the hook queue is empty.
-func (f *VCSSyncerCloneFunc) SetDefaultHook(hook func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error) {
+func (f *VCSSyncerCloneFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, io.Writer) error) {
 	f.defaultHook = hook
 }
 
@@ -134,7 +134,7 @@ func (f *VCSSyncerCloneFunc) SetDefaultHook(hook func(context.Context, api.RepoN
 // Clone method of the parent MockVCSSyncer instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *VCSSyncerCloneFunc) PushHook(hook func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error) {
+func (f *VCSSyncerCloneFunc) PushHook(hook func(context.Context, api.RepoName, string, io.Writer) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -143,19 +143,19 @@ func (f *VCSSyncerCloneFunc) PushHook(hook func(context.Context, api.RepoName, c
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *VCSSyncerCloneFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error {
+	f.SetDefaultHook(func(context.Context, api.RepoName, string, io.Writer) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *VCSSyncerCloneFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error {
+	f.PushHook(func(context.Context, api.RepoName, string, io.Writer) error {
 		return r0
 	})
 }
 
-func (f *VCSSyncerCloneFunc) nextHook() func(context.Context, api.RepoName, common.GitDir, string, io.Writer) error {
+func (f *VCSSyncerCloneFunc) nextHook() func(context.Context, api.RepoName, string, io.Writer) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -196,13 +196,10 @@ type VCSSyncerCloneFuncCall struct {
 	Arg1 api.RepoName
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 common.GitDir
+	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 io.Writer
+	Arg3 io.Writer
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -211,7 +208,7 @@ type VCSSyncerCloneFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c VCSSyncerCloneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this

--- a/cmd/gitserver/internal/vcssyncer/packages_syncer.go
+++ b/cmd/gitserver/internal/vcssyncer/packages_syncer.go
@@ -81,7 +81,7 @@ func (s *vcsPackagesSyncer) Type() string {
 // Clone writes a package and all requested versions of it into a synthetic git
 // repo at tmpPath by creating one head per version.
 // It reports redacted progress logs via the progressWriter.
-func (s *vcsPackagesSyncer) Clone(ctx context.Context, repo api.RepoName, _ common.GitDir, tmpPath string, progressWriter io.Writer) (err error) {
+func (s *vcsPackagesSyncer) Clone(ctx context.Context, repo api.RepoName, tmpPath string, progressWriter io.Writer) (err error) {
 	// First, make sure the tmpPath exists.
 	if err := os.MkdirAll(tmpPath, os.ModePerm); err != nil {
 		return errors.Wrapf(err, "clone failed to create tmp dir")

--- a/cmd/gitserver/internal/vcssyncer/perforce.go
+++ b/cmd/gitserver/internal/vcssyncer/perforce.go
@@ -87,7 +87,7 @@ func (s *perforceDepotSyncer) IsCloneable(ctx context.Context, repoName api.Repo
 
 // Clone writes a Perforce depot into tmpPath, using a Perforce-to-git-conversion.
 // It reports redacted progress logs via the progressWriter.
-func (s *perforceDepotSyncer) Clone(ctx context.Context, repo api.RepoName, _ common.GitDir, tmpPath string, progressWriter io.Writer) (err error) {
+func (s *perforceDepotSyncer) Clone(ctx context.Context, repo api.RepoName, tmpPath string, progressWriter io.Writer) (err error) {
 	source, err := s.getRemoteURLSource(ctx, repo)
 	if err != nil {
 		return errors.Wrap(err, "getting remote URL source")

--- a/cmd/gitserver/internal/vcssyncer/refspecoverrides.go
+++ b/cmd/gitserver/internal/vcssyncer/refspecoverrides.go
@@ -1,26 +1,23 @@
 package vcssyncer
 
 import (
-	"context"
-	"os/exec"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
 // HACK(keegancsmith) workaround to experiment with cloning less in a large
 // monorepo. https://github.com/sourcegraph/customer/issues/19
-var refspecOverrides = strings.Fields(env.Get("SRC_GITSERVER_REFSPECS", "", "EXPERIMENTAL: override refspec we fetch. Space separated."))
+var refspecOverridesEnv = strings.Fields(env.Get("SRC_GITSERVER_REFSPECS", "", "EXPERIMENTAL: override refspec we fetch. Space separated."))
 
 // HACK(keegancsmith) workaround to experiment with cloning less in a large
 // monorepo. https://github.com/sourcegraph/customer/issues/19
 func useRefspecOverrides() bool {
-	return len(refspecOverrides) > 0
+	return len(refspecOverridesEnv) > 0
 }
 
 // HACK(keegancsmith) workaround to experiment with cloning less in a large
 // monorepo. https://github.com/sourcegraph/customer/issues/19
-func refspecOverridesFetchCmd(ctx context.Context, remoteURL *vcs.URL) *exec.Cmd {
-	return exec.CommandContext(ctx, "git", append([]string{"fetch", "--progress", "--prune", remoteURL.String()}, refspecOverrides...)...)
+func refspecOverrides() []string {
+	return append([]string{}, refspecOverridesEnv...)
 }

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -130,6 +130,9 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 					}), nil
 				},
+				GetBackendFunc: func(dir common.GitDir, repoName api.RepoName) git.GitBackend {
+					return git.NewObservableBackend(gitcli.NewBackend(logger, recordingCommandFactory, dir, repoName))
+				},
 			})
 		},
 		FS:                      fs,


### PR DESCRIPTION
This PR moves Fetch to the GitBackend to benefit from all the observability and so forth that this package provides. Also, it's a git command. All git commands should live here eventually.

Test plan:

E2E tests verify that fetching still works.
