### PR TITLE
gitserver: Better clean up after state changes

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -741,8 +741,19 @@ func TestRepositories_Integration(t *testing.T) {
 		if err := gitserverRepos.SetRepoSize(ctx, rsc.repo.Name, rsc.size, "shard-1"); err != nil {
 			t.Fatal(err)
 		}
-		if err := gitserverRepos.SetCloneStatus(ctx, rsc.repo.Name, rsc.cloneStatus, "shard-1"); err != nil {
-			t.Fatal(err)
+		switch rsc.cloneStatus {
+		case types.CloneStatusCloned:
+			if err := gitserverRepos.SetCloned(ctx, rsc.repo.Name, "shard-1"); err != nil {
+				t.Fatal(err)
+			}
+		case types.CloneStatusCloning:
+			if err := gitserverRepos.SetCloning(ctx, rsc.repo.Name, "shard-1"); err != nil {
+				t.Fatal(err)
+			}
+		case types.CloneStatusNotCloned:
+			if err := gitserverRepos.SetNotCloned(ctx, rsc.repo.Name); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		if rsc.indexed {

--- a/cmd/gitserver/internal/cleanup_test.go
+++ b/cmd/gitserver/internal/cleanup_test.go
@@ -811,12 +811,12 @@ func TestFreeUpSpace(t *testing.T) {
 	fs := gitserverfs.New(observation.TestContextTB(t), root)
 	require.NoError(t, fs.Initialize())
 	t.Run("no error if no space requested and no repos", func(t *testing.T) {
-		if err := freeUpSpace(context.Background(), logger, newMockedGitserverDB(), fs, "test-gitserver", &fakeDiskUsage{}, 10, 0); err != nil {
+		if err := freeUpSpace(context.Background(), logger, newMockedGitserverDB(), fs, &fakeDiskUsage{}, 10, 0); err != nil {
 			t.Fatal(err)
 		}
 	})
 	t.Run("error if space requested and no repos", func(t *testing.T) {
-		if err := freeUpSpace(context.Background(), logger, newMockedGitserverDB(), fs, "test-gitserver", &fakeDiskUsage{}, 10, 1); err == nil {
+		if err := freeUpSpace(context.Background(), logger, newMockedGitserverDB(), fs, &fakeDiskUsage{}, 10, 1); err == nil {
 			t.Fatal("want error")
 		}
 	})
@@ -843,7 +843,7 @@ func TestFreeUpSpace(t *testing.T) {
 		gr := dbmocks.NewMockGitserverRepoStore()
 		db.GitserverReposFunc.SetDefaultReturn(gr)
 		// Run.
-		if err := freeUpSpace(context.Background(), logger, db, fs, "test-gitserver", &fakeDiskUsage{}, 10, 1000); err != nil {
+		if err := freeUpSpace(context.Background(), logger, db, fs, &fakeDiskUsage{}, 10, 1000); err != nil {
 			t.Fatal(err)
 		}
 
@@ -860,10 +860,9 @@ func TestFreeUpSpace(t *testing.T) {
 			t.Errorf("repo dir size is %d, want no more than %d", rds, wantSize)
 		}
 
-		if len(gr.SetCloneStatusFunc.History()) == 0 {
-			t.Fatal("expected gitserverRepos.SetCloneStatus to be called, but wasn't")
+		if len(gr.SetNotClonedFunc.History()) == 0 {
+			t.Fatal("expected gitserverRepos.SetNotCloned to be called, but wasn't")
 		}
-		require.Equal(t, gr.SetCloneStatusFunc.History()[0].Arg2, types.CloneStatusNotCloned)
 	})
 }
 

--- a/cmd/gitserver/internal/integration_tests/utils_test.go
+++ b/cmd/gitserver/internal/integration_tests/utils_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
 	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
@@ -44,9 +43,8 @@ var root string
 // This is a default gitserver test client currently used for RequestRepoUpdate
 // gitserver calls during invocation of MakeGitRepository function
 var (
-	testGitserverClient gitserver.Client
-	GitserverAddresses  []string
-	testServer          *server.Server
+	GitserverAddresses []string
+	testServer         *server.Server
 )
 
 func InitGitserver() {
@@ -135,8 +133,6 @@ func InitGitserver() {
 	}()
 
 	serverAddress := l.Addr().String()
-	source := gitserver.NewTestClientSource(&t, []string{serverAddress})
-	testGitserverClient = gitserver.NewTestClient(&t).WithClientSource(source)
 	GitserverAddresses = []string{serverAddress}
 	testServer = s
 }

--- a/cmd/gitserver/internal/repo_info.go
+++ b/cmd/gitserver/internal/repo_info.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -35,7 +34,6 @@ func repoCloneProgress(fs gitserverfs.FS, locker RepositoryLocker, repo api.Repo
 func deleteRepo(
 	ctx context.Context,
 	db database.DB,
-	shardID string,
 	fs gitserverfs.FS,
 	repo api.RepoName,
 ) error {
@@ -44,7 +42,7 @@ func deleteRepo(
 		return errors.Wrap(err, "removing repo directory")
 	}
 
-	err = db.GitserverRepos().SetCloneStatus(ctx, repo, types.CloneStatusNotCloned, shardID)
+	err = db.GitserverRepos().SetNotCloned(ctx, repo)
 	if err != nil {
 		return errors.Wrap(err, "setting clone status after delete")
 	}

--- a/cmd/gitserver/internal/repo_info_test.go
+++ b/cmd/gitserver/internal/repo_info_test.go
@@ -92,7 +92,7 @@ func testDeleteRepo(t *testing.T, deletedInDB bool) {
 	}
 
 	// Now we can delete it
-	require.NoError(t, deleteRepo(ctx, db, "", s.fs, dbRepo.Name))
+	require.NoError(t, deleteRepo(ctx, db, s.fs, dbRepo.Name))
 
 	size, err = s.fs.DirSize(string(s.fs.RepoDir(repoName)))
 	require.NoError(t, err)

--- a/cmd/gitserver/internal/repositoryservice.go
+++ b/cmd/gitserver/internal/repositoryservice.go
@@ -72,7 +72,7 @@ func (s *repositoryServiceServer) DeleteRepository(ctx context.Context, req *pro
 		return nil, status.New(codes.NotFound, "repository not found").Err()
 	}
 
-	if err := deleteRepo(ctx, s.db, s.hostname, s.fs, repoName); err != nil {
+	if err := deleteRepo(ctx, s.db, s.fs, repoName); err != nil {
 		s.logger.Error("failed to delete repository", log.String("repo", string(repoName)), log.Error(err))
 		return &proto.DeleteRepositoryResponse{}, status.Errorf(codes.Internal, "failed to delete repository %s: %s", repoName, err)
 	}
@@ -121,6 +121,8 @@ func (s *repositoryServiceServer) FetchRepository(req *proto.FetchRepositoryRequ
 
 	lastFetched, lastChanged, err := s.svc.FetchRepository(ss.Context(), repoName)
 	if err != nil {
+		s.svc.LogIfCorrupt(context.Background(), repoName, err)
+
 		return status.New(codes.Internal, errors.Wrap(err, "failed to fetch repository").Error()).Err()
 	}
 

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -37105,9 +37105,12 @@ type MockGitserverRepoStore struct {
 	// LogCorruptionFunc is an instance of a mock function object
 	// controlling the behavior of the method LogCorruption.
 	LogCorruptionFunc *GitserverRepoStoreLogCorruptionFunc
-	// SetCloneStatusFunc is an instance of a mock function object
-	// controlling the behavior of the method SetCloneStatus.
-	SetCloneStatusFunc *GitserverRepoStoreSetCloneStatusFunc
+	// SetClonedFunc is an instance of a mock function object controlling
+	// the behavior of the method SetCloned.
+	SetClonedFunc *GitserverRepoStoreSetClonedFunc
+	// SetCloningFunc is an instance of a mock function object controlling
+	// the behavior of the method SetCloning.
+	SetCloningFunc *GitserverRepoStoreSetCloningFunc
 	// SetLastErrorFunc is an instance of a mock function object controlling
 	// the behavior of the method SetLastError.
 	SetLastErrorFunc *GitserverRepoStoreSetLastErrorFunc
@@ -37117,6 +37120,9 @@ type MockGitserverRepoStore struct {
 	// SetLastOutputFunc is an instance of a mock function object
 	// controlling the behavior of the method SetLastOutput.
 	SetLastOutputFunc *GitserverRepoStoreSetLastOutputFunc
+	// SetNotClonedFunc is an instance of a mock function object controlling
+	// the behavior of the method SetNotCloned.
+	SetNotClonedFunc *GitserverRepoStoreSetNotClonedFunc
 	// SetRepoSizeFunc is an instance of a mock function object controlling
 	// the behavior of the method SetRepoSize.
 	SetRepoSizeFunc *GitserverRepoStoreSetRepoSizeFunc
@@ -37190,8 +37196,13 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 				return
 			},
 		},
-		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
-			defaultHook: func(context.Context, api.RepoName, types.CloneStatus, string) (r0 error) {
+		SetClonedFunc: &GitserverRepoStoreSetClonedFunc{
+			defaultHook: func(context.Context, api.RepoName, string) (r0 error) {
+				return
+			},
+		},
+		SetCloningFunc: &GitserverRepoStoreSetCloningFunc{
+			defaultHook: func(context.Context, api.RepoName, string) (r0 error) {
 				return
 			},
 		},
@@ -37207,6 +37218,11 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 		},
 		SetLastOutputFunc: &GitserverRepoStoreSetLastOutputFunc{
 			defaultHook: func(context.Context, api.RepoName, string) (r0 error) {
+				return
+			},
+		},
+		SetNotClonedFunc: &GitserverRepoStoreSetNotClonedFunc{
+			defaultHook: func(context.Context, api.RepoName) (r0 error) {
 				return
 			},
 		},
@@ -37293,9 +37309,14 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 				panic("unexpected invocation of MockGitserverRepoStore.LogCorruption")
 			},
 		},
-		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
-			defaultHook: func(context.Context, api.RepoName, types.CloneStatus, string) error {
-				panic("unexpected invocation of MockGitserverRepoStore.SetCloneStatus")
+		SetClonedFunc: &GitserverRepoStoreSetClonedFunc{
+			defaultHook: func(context.Context, api.RepoName, string) error {
+				panic("unexpected invocation of MockGitserverRepoStore.SetCloned")
+			},
+		},
+		SetCloningFunc: &GitserverRepoStoreSetCloningFunc{
+			defaultHook: func(context.Context, api.RepoName, string) error {
+				panic("unexpected invocation of MockGitserverRepoStore.SetCloning")
 			},
 		},
 		SetLastErrorFunc: &GitserverRepoStoreSetLastErrorFunc{
@@ -37311,6 +37332,11 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 		SetLastOutputFunc: &GitserverRepoStoreSetLastOutputFunc{
 			defaultHook: func(context.Context, api.RepoName, string) error {
 				panic("unexpected invocation of MockGitserverRepoStore.SetLastOutput")
+			},
+		},
+		SetNotClonedFunc: &GitserverRepoStoreSetNotClonedFunc{
+			defaultHook: func(context.Context, api.RepoName) error {
+				panic("unexpected invocation of MockGitserverRepoStore.SetNotCloned")
 			},
 		},
 		SetRepoSizeFunc: &GitserverRepoStoreSetRepoSizeFunc{
@@ -37376,8 +37402,11 @@ func NewMockGitserverRepoStoreFrom(i database.GitserverRepoStore) *MockGitserver
 		LogCorruptionFunc: &GitserverRepoStoreLogCorruptionFunc{
 			defaultHook: i.LogCorruption,
 		},
-		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
-			defaultHook: i.SetCloneStatus,
+		SetClonedFunc: &GitserverRepoStoreSetClonedFunc{
+			defaultHook: i.SetCloned,
+		},
+		SetCloningFunc: &GitserverRepoStoreSetCloningFunc{
+			defaultHook: i.SetCloning,
 		},
 		SetLastErrorFunc: &GitserverRepoStoreSetLastErrorFunc{
 			defaultHook: i.SetLastError,
@@ -37387,6 +37416,9 @@ func NewMockGitserverRepoStoreFrom(i database.GitserverRepoStore) *MockGitserver
 		},
 		SetLastOutputFunc: &GitserverRepoStoreSetLastOutputFunc{
 			defaultHook: i.SetLastOutput,
+		},
+		SetNotClonedFunc: &GitserverRepoStoreSetNotClonedFunc{
+			defaultHook: i.SetNotCloned,
 		},
 		SetRepoSizeFunc: &GitserverRepoStoreSetRepoSizeFunc{
 			defaultHook: i.SetRepoSize,
@@ -38510,37 +38542,35 @@ func (c GitserverRepoStoreLogCorruptionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// GitserverRepoStoreSetCloneStatusFunc describes the behavior when the
-// SetCloneStatus method of the parent MockGitserverRepoStore instance is
-// invoked.
-type GitserverRepoStoreSetCloneStatusFunc struct {
-	defaultHook func(context.Context, api.RepoName, types.CloneStatus, string) error
-	hooks       []func(context.Context, api.RepoName, types.CloneStatus, string) error
-	history     []GitserverRepoStoreSetCloneStatusFuncCall
+// GitserverRepoStoreSetClonedFunc describes the behavior when the SetCloned
+// method of the parent MockGitserverRepoStore instance is invoked.
+type GitserverRepoStoreSetClonedFunc struct {
+	defaultHook func(context.Context, api.RepoName, string) error
+	hooks       []func(context.Context, api.RepoName, string) error
+	history     []GitserverRepoStoreSetClonedFuncCall
 	mutex       sync.Mutex
 }
 
-// SetCloneStatus delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) SetCloneStatus(v0 context.Context, v1 api.RepoName, v2 types.CloneStatus, v3 string) error {
-	r0 := m.SetCloneStatusFunc.nextHook()(v0, v1, v2, v3)
-	m.SetCloneStatusFunc.appendCall(GitserverRepoStoreSetCloneStatusFuncCall{v0, v1, v2, v3, r0})
+// SetCloned delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) SetCloned(v0 context.Context, v1 api.RepoName, v2 string) error {
+	r0 := m.SetClonedFunc.nextHook()(v0, v1, v2)
+	m.SetClonedFunc.appendCall(GitserverRepoStoreSetClonedFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the SetCloneStatus
-// method of the parent MockGitserverRepoStore instance is invoked and the
-// hook queue is empty.
-func (f *GitserverRepoStoreSetCloneStatusFunc) SetDefaultHook(hook func(context.Context, api.RepoName, types.CloneStatus, string) error) {
+// SetDefaultHook sets function that is called when the SetCloned method of
+// the parent MockGitserverRepoStore instance is invoked and the hook queue
+// is empty.
+func (f *GitserverRepoStoreSetClonedFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// SetCloneStatus method of the parent MockGitserverRepoStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *GitserverRepoStoreSetCloneStatusFunc) PushHook(hook func(context.Context, api.RepoName, types.CloneStatus, string) error) {
+// SetCloned method of the parent MockGitserverRepoStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverRepoStoreSetClonedFunc) PushHook(hook func(context.Context, api.RepoName, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -38548,20 +38578,20 @@ func (f *GitserverRepoStoreSetCloneStatusFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverRepoStoreSetCloneStatusFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, types.CloneStatus, string) error {
+func (f *GitserverRepoStoreSetClonedFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreSetCloneStatusFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, api.RepoName, types.CloneStatus, string) error {
+func (f *GitserverRepoStoreSetClonedFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, api.RepoName, string) error {
 		return r0
 	})
 }
 
-func (f *GitserverRepoStoreSetCloneStatusFunc) nextHook() func(context.Context, api.RepoName, types.CloneStatus, string) error {
+func (f *GitserverRepoStoreSetClonedFunc) nextHook() func(context.Context, api.RepoName, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -38574,27 +38604,26 @@ func (f *GitserverRepoStoreSetCloneStatusFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *GitserverRepoStoreSetCloneStatusFunc) appendCall(r0 GitserverRepoStoreSetCloneStatusFuncCall) {
+func (f *GitserverRepoStoreSetClonedFunc) appendCall(r0 GitserverRepoStoreSetClonedFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of GitserverRepoStoreSetCloneStatusFuncCall
-// objects describing the invocations of this function.
-func (f *GitserverRepoStoreSetCloneStatusFunc) History() []GitserverRepoStoreSetCloneStatusFuncCall {
+// History returns a sequence of GitserverRepoStoreSetClonedFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverRepoStoreSetClonedFunc) History() []GitserverRepoStoreSetClonedFuncCall {
 	f.mutex.Lock()
-	history := make([]GitserverRepoStoreSetCloneStatusFuncCall, len(f.history))
+	history := make([]GitserverRepoStoreSetClonedFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// GitserverRepoStoreSetCloneStatusFuncCall is an object that describes an
-// invocation of method SetCloneStatus on an instance of
-// MockGitserverRepoStore.
-type GitserverRepoStoreSetCloneStatusFuncCall struct {
+// GitserverRepoStoreSetClonedFuncCall is an object that describes an
+// invocation of method SetCloned on an instance of MockGitserverRepoStore.
+type GitserverRepoStoreSetClonedFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -38603,10 +38632,7 @@ type GitserverRepoStoreSetCloneStatusFuncCall struct {
 	Arg1 api.RepoName
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 types.CloneStatus
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
+	Arg2 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -38614,13 +38640,122 @@ type GitserverRepoStoreSetCloneStatusFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverRepoStoreSetCloneStatusFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverRepoStoreSetClonedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverRepoStoreSetCloneStatusFuncCall) Results() []interface{} {
+func (c GitserverRepoStoreSetClonedFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// GitserverRepoStoreSetCloningFunc describes the behavior when the
+// SetCloning method of the parent MockGitserverRepoStore instance is
+// invoked.
+type GitserverRepoStoreSetCloningFunc struct {
+	defaultHook func(context.Context, api.RepoName, string) error
+	hooks       []func(context.Context, api.RepoName, string) error
+	history     []GitserverRepoStoreSetCloningFuncCall
+	mutex       sync.Mutex
+}
+
+// SetCloning delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) SetCloning(v0 context.Context, v1 api.RepoName, v2 string) error {
+	r0 := m.SetCloningFunc.nextHook()(v0, v1, v2)
+	m.SetCloningFunc.appendCall(GitserverRepoStoreSetCloningFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the SetCloning method of
+// the parent MockGitserverRepoStore instance is invoked and the hook queue
+// is empty.
+func (f *GitserverRepoStoreSetCloningFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SetCloning method of the parent MockGitserverRepoStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverRepoStoreSetCloningFunc) PushHook(hook func(context.Context, api.RepoName, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverRepoStoreSetCloningFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverRepoStoreSetCloningFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, api.RepoName, string) error {
+		return r0
+	})
+}
+
+func (f *GitserverRepoStoreSetCloningFunc) nextHook() func(context.Context, api.RepoName, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverRepoStoreSetCloningFunc) appendCall(r0 GitserverRepoStoreSetCloningFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverRepoStoreSetCloningFuncCall
+// objects describing the invocations of this function.
+func (f *GitserverRepoStoreSetCloningFunc) History() []GitserverRepoStoreSetCloningFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverRepoStoreSetCloningFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverRepoStoreSetCloningFuncCall is an object that describes an
+// invocation of method SetCloning on an instance of MockGitserverRepoStore.
+type GitserverRepoStoreSetCloningFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoName
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverRepoStoreSetCloningFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverRepoStoreSetCloningFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -38956,6 +39091,113 @@ func (c GitserverRepoStoreSetLastOutputFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverRepoStoreSetLastOutputFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// GitserverRepoStoreSetNotClonedFunc describes the behavior when the
+// SetNotCloned method of the parent MockGitserverRepoStore instance is
+// invoked.
+type GitserverRepoStoreSetNotClonedFunc struct {
+	defaultHook func(context.Context, api.RepoName) error
+	hooks       []func(context.Context, api.RepoName) error
+	history     []GitserverRepoStoreSetNotClonedFuncCall
+	mutex       sync.Mutex
+}
+
+// SetNotCloned delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) SetNotCloned(v0 context.Context, v1 api.RepoName) error {
+	r0 := m.SetNotClonedFunc.nextHook()(v0, v1)
+	m.SetNotClonedFunc.appendCall(GitserverRepoStoreSetNotClonedFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the SetNotCloned method
+// of the parent MockGitserverRepoStore instance is invoked and the hook
+// queue is empty.
+func (f *GitserverRepoStoreSetNotClonedFunc) SetDefaultHook(hook func(context.Context, api.RepoName) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SetNotCloned method of the parent MockGitserverRepoStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverRepoStoreSetNotClonedFunc) PushHook(hook func(context.Context, api.RepoName) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverRepoStoreSetNotClonedFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverRepoStoreSetNotClonedFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, api.RepoName) error {
+		return r0
+	})
+}
+
+func (f *GitserverRepoStoreSetNotClonedFunc) nextHook() func(context.Context, api.RepoName) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverRepoStoreSetNotClonedFunc) appendCall(r0 GitserverRepoStoreSetNotClonedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverRepoStoreSetNotClonedFuncCall
+// objects describing the invocations of this function.
+func (f *GitserverRepoStoreSetNotClonedFunc) History() []GitserverRepoStoreSetNotClonedFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverRepoStoreSetNotClonedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverRepoStoreSetNotClonedFuncCall is an object that describes an
+// invocation of method SetNotCloned on an instance of
+// MockGitserverRepoStore.
+type GitserverRepoStoreSetNotClonedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoName
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverRepoStoreSetNotClonedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverRepoStoreSetNotClonedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -720,7 +720,7 @@ func TestLogCorruption(t *testing.T) {
 		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo7")
 
 		// Mark it as cloned on shard-1
-		err := db.GitserverRepos().SetCloneStatus(ctx, repo.Name, types.CloneStatusCloned, "shard-1")
+		err := db.GitserverRepos().SetCloned(ctx, repo.Name, "shard-1")
 		require.NoError(t, err)
 
 		// Log corruption on shard-2
@@ -1225,7 +1225,7 @@ func TestGitserverRepos_GetGitserverGitDirSize(t *testing.T) {
 	assertSize(700)
 
 	// Now mark the repo as uncloned, that should exclude it from statistics.
-	require.NoError(t, db.GitserverRepos().SetCloneStatus(ctx, repo.Name, types.CloneStatusNotCloned, "test-gitserver"))
+	require.NoError(t, db.GitserverRepos().SetNotCloned(ctx, repo.Name))
 
 	// only repo2 which is 500 bytes should cont now.
 	assertSize(500)

--- a/internal/database/repo_statistics_test.go
+++ b/internal/database/repo_statistics_test.go
@@ -683,8 +683,19 @@ func queryGitserverReposStatisticsCount(t *testing.T, ctx context.Context, s *re
 
 func setCloneStatus(t *testing.T, db DB, repoName api.RepoName, shard string, status types.CloneStatus) {
 	t.Helper()
-	if err := db.GitserverRepos().SetCloneStatus(context.Background(), repoName, status, shard); err != nil {
-		t.Fatalf("failed to set clone status for repo %s: %s", repoName, err)
+	switch status {
+	case types.CloneStatusCloned:
+		if err := db.GitserverRepos().SetCloned(context.Background(), repoName, shard); err != nil {
+			t.Fatalf("failed to set clone status for repo %s: %s", repoName, err)
+		}
+	case types.CloneStatusCloning:
+		if err := db.GitserverRepos().SetCloning(context.Background(), repoName, shard); err != nil {
+			t.Fatalf("failed to set clone status for repo %s: %s", repoName, err)
+		}
+	case types.CloneStatusNotCloned:
+		if err := db.GitserverRepos().SetNotCloned(context.Background(), repoName); err != nil {
+			t.Fatalf("failed to set clone status for repo %s: %s", repoName, err)
+		}
 	}
 }
 

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -97,8 +97,19 @@ func mustCreate(ctx context.Context, t *testing.T, db DB, repo *types.Repo) *typ
 func setGitserverRepoCloneStatus(t *testing.T, db DB, name api.RepoName, s types.CloneStatus) {
 	t.Helper()
 
-	if err := db.GitserverRepos().SetCloneStatus(context.Background(), name, s, shardID); err != nil {
-		t.Fatal(err)
+	switch s {
+	case types.CloneStatusCloned:
+		if err := db.GitserverRepos().SetCloned(context.Background(), name, shardID); err != nil {
+			t.Fatalf("failed to set clone status for repo %s: %s", name, err)
+		}
+	case types.CloneStatusCloning:
+		if err := db.GitserverRepos().SetCloning(context.Background(), name, shardID); err != nil {
+			t.Fatalf("failed to set clone status for repo %s: %s", name, err)
+		}
+	case types.CloneStatusNotCloned:
+		if err := db.GitserverRepos().SetNotCloned(context.Background(), name); err != nil {
+			t.Fatalf("failed to set clone status for repo %s: %s", name, err)
+		}
 	}
 }
 

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -215,10 +215,10 @@ func TestGetEmbeddableRepos(t *testing.T) {
 
 	// Clone the repos
 	gitserverStore := db.GitserverRepos()
-	err = gitserverStore.SetCloneStatus(ctx, firstRepo.Name, types.CloneStatusCloned, "test")
+	err = gitserverStore.SetCloned(ctx, firstRepo.Name, "test")
 	require.NoError(t, err)
 
-	err = gitserverStore.SetCloneStatus(ctx, secondRepo.Name, types.CloneStatusCloned, "test")
+	err = gitserverStore.SetCloned(ctx, secondRepo.Name, "test")
 	require.NoError(t, err)
 
 	// Create a embeddings policy that applies to all repos
@@ -258,10 +258,10 @@ func TestEmbeddingsPolicyWithFailures(t *testing.T) {
 
 	// Clone the repos
 	gitserverStore := db.GitserverRepos()
-	err = gitserverStore.SetCloneStatus(ctx, firstRepo.Name, types.CloneStatusCloned, "test")
+	err = gitserverStore.SetCloned(ctx, firstRepo.Name, "test")
 	require.NoError(t, err)
 
-	err = gitserverStore.SetCloneStatus(ctx, secondRepo.Name, types.CloneStatusCloned, "test")
+	err = gitserverStore.SetCloned(ctx, secondRepo.Name, "test")
 	require.NoError(t, err)
 
 	// Create a embeddings policy that applies to all repos
@@ -301,10 +301,10 @@ func TestGetEmbeddableReposLimit(t *testing.T) {
 
 	// Clone the repos
 	gitserverStore := db.GitserverRepos()
-	err = gitserverStore.SetCloneStatus(ctx, firstRepo.Name, types.CloneStatusCloned, "test")
+	err = gitserverStore.SetCloned(ctx, firstRepo.Name, "test")
 	require.NoError(t, err)
 
-	err = gitserverStore.SetCloneStatus(ctx, secondRepo.Name, types.CloneStatusCloned, "test")
+	err = gitserverStore.SetCloned(ctx, secondRepo.Name, "test")
 	require.NoError(t, err)
 
 	// Create an embeddings policy that applies to all repos


### PR DESCRIPTION
The database is not super clean when we do state changes, for example we keep the repo size after marking as not cloned, and keep shard assignments, too.

This PR splits those operations into three, and resets more rows.

Test plan:

Cloning and tests around clone status calls are still passing.