### PR TITLE
gitserver: Implement UploadPack in git CLI

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/uploadpack.go
+++ b/cmd/gitserver/internal/git/gitcli/uploadpack.go
@@ -1,0 +1,48 @@
+package gitcli
+
+import (
+	"context"
+	"io"
+
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
+)
+
+func (g *gitCLIBackend) UploadPack(ctx context.Context, input io.Reader, protocol string, advertiseRefs bool) (io.ReadCloser, error) {
+	args := buildUploadPackArgs(advertiseRefs, g.dir)
+
+	opts := []CommandOptionFunc{
+		WithStdin(input),
+		WithArguments(args...),
+	}
+	if protocol != "" {
+		opts = append(opts, WithEnv("GIT_PROTOCOL="+protocol))
+	}
+
+	return g.NewCommand(ctx, "upload-pack", opts...)
+}
+
+func buildUploadPackArgs(advertiseRefs bool, dir common.GitDir) []Argument {
+	args := []Argument{
+		// Allow partial clones/fetches.
+		ConfigArgument{Key: "uploadpack.allowFilter", Value: "true"},
+
+		// Allow to fetch any object. Used in case of race between a resolve ref
+		// and a fetch of a commit. Safe to do, since this is only used internally.
+		ConfigArgument{Key: "uploadpack.allowAnySHA1InWant", Value: "true"},
+
+		// The maximum size of memory that is consumed by each thread in git-pack-objects[1]
+		// for pack window memory when no limit is given on the command line.
+		//
+		// Important for large monorepos to not run into memory issues when cloned.
+		ConfigArgument{Key: "pack.windowMemory", Value: "100m"},
+
+		FlagArgument{"--stateless-rpc"}, FlagArgument{"--strict"},
+	}
+	if advertiseRefs {
+		args = append(args, FlagArgument{"--advertise-refs"})
+	}
+
+	args = append(args, SpecSafeValueArgument{string(dir)})
+
+	return args
+}

--- a/cmd/gitserver/internal/git/gitcli/uploadpack_test.go
+++ b/cmd/gitserver/internal/git/gitcli/uploadpack_test.go
@@ -1,0 +1,145 @@
+package gitcli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
+)
+
+// // numTestCommits determines the number of files/commits/tags to create for
+// // the local test repo. The value of 25 causes clonev1 and clonev2 to use gzip
+// // compression but shallow to be uncompressed. The value of 10 does not trigger
+// // this same behavior.
+// const numTestCommits = 25
+
+// func TestHandler(t *testing.T) {
+// 	root := t.TempDir()
+// 	repo := filepath.Join(root, "testrepo")
+
+// 	// Setup a repo with a commit so we can add bad refs
+// 	runCmd(t, root, "git", "init", repo)
+
+// 	for i := range numTestCommits {
+// 		runCmd(t, repo, "sh", "-c", fmt.Sprintf("echo hello world > hello-%d.txt", i+1))
+// 		runCmd(t, repo, "git", "add", fmt.Sprintf("hello-%d.txt", i+1))
+// 		runCmd(t, repo, "git", "commit", "-m", fmt.Sprintf("c%d", i+1))
+// 		runCmd(t, repo, "git", "tag", fmt.Sprintf("v%d", i+1))
+// 	}
+
+// 	ts := httptest.NewServer(&gitservice.Handler{
+// 		Dir: func(s string) string {
+// 			return filepath.Join(root, s, ".git")
+// 		},
+// 	})
+// 	defer ts.Close()
+
+// 	t.Run("404", func(t *testing.T) {
+// 		c := exec.Command("git", "clone", ts.URL+"/doesnotexist")
+// 		c.Dir = t.TempDir()
+// 		b, err := c.CombinedOutput()
+// 		if !bytes.Contains(b, []byte("repository not found")) {
+// 			t.Fatal("expected clone to fail with repository not found", string(b), err)
+// 		}
+// 	})
+
+// 	cloneURL := ts.URL + "/testrepo"
+
+// 	t.Run("clonev1", func(t *testing.T) {
+// 		runCmd(t, t.TempDir(), "git", "-c", "protocol.version=1", "clone", cloneURL)
+// 	})
+
+// 	cloneV2 := []struct {
+// 		Name string
+// 		Args []string
+// 	}{{
+// 		"clonev2",
+// 		[]string{},
+// 	}, {
+// 		"shallow",
+// 		[]string{"--depth=1"},
+// 	}}
+
+// 	for _, tc := range cloneV2 {
+// 		t.Run(tc.Name, func(t *testing.T) {
+// 			args := []string{"-c", "protocol.version=2", "clone"}
+// 			args = append(args, tc.Args...)
+// 			args = append(args, cloneURL)
+
+// 			c := exec.Command("git", args...)
+// 			c.Dir = t.TempDir()
+// 			c.Env = []string{
+// 				"GIT_TRACE_PACKET=1",
+// 			}
+// 			b, err := c.CombinedOutput()
+// 			if err != nil {
+// 				t.Fatalf("command failed: %s\nOutput: %s", err, b)
+// 			}
+
+// 			// This is the same test done by git's tests for checking if the
+// 			// server is using protocol v2.
+// 			if !bytes.Contains(b, []byte("git< version 2")) {
+// 				t.Fatalf("protocol v2 not used by server. Output:\n%s", b)
+// 			}
+// 		})
+// 	}
+// }
+
+// func runCmd(t *testing.T, dir string, cmd string, arg ...string) {
+// 	t.Helper()
+// 	c := exec.Command(cmd, arg...)
+// 	c.Dir = dir
+// 	c.Env = []string{
+// 		"GIT_COMMITTER_NAME=a",
+// 		"GIT_COMMITTER_EMAIL=a@a.com",
+// 		"GIT_AUTHOR_NAME=a",
+// 		"GIT_AUTHOR_EMAIL=a@a.com",
+// 	}
+// 	b, err := c.CombinedOutput()
+// 	if err != nil {
+// 		t.Fatalf("%s %s failed: %s\nOutput: %s", cmd, strings.Join(arg, " "), err, b)
+// 	}
+// }
+
+func TestBuildUploadPackArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		advertiseRefs bool
+		dir           common.GitDir
+		want          []Argument
+	}{
+		{
+			name:          "advertise refs",
+			advertiseRefs: true,
+			dir:           common.GitDir("/path/to/repo/.git"),
+			want: []Argument{
+				ConfigArgument{Key: "uploadpack.allowFilter", Value: "true"},
+				ConfigArgument{Key: "uploadpack.allowAnySHA1InWant", Value: "true"},
+				ConfigArgument{Key: "pack.windowMemory", Value: "100m"},
+				FlagArgument{"--stateless-rpc"}, FlagArgument{"--strict"},
+				FlagArgument{"--advertise-refs"},
+				SpecSafeValueArgument{"/path/to/repo/.git"},
+			},
+		},
+		{
+			name:          "no advertise refs",
+			advertiseRefs: false,
+			dir:           common.GitDir("/path/to/repo/.git"),
+			want: []Argument{
+				ConfigArgument{Key: "uploadpack.allowFilter", Value: "true"},
+				ConfigArgument{Key: "uploadpack.allowAnySHA1InWant", Value: "true"},
+				ConfigArgument{Key: "pack.windowMemory", Value: "100m"},
+				FlagArgument{"--stateless-rpc"}, FlagArgument{"--strict"},
+				SpecSafeValueArgument{"/path/to/repo/.git"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildUploadPackArgs(test.advertiseRefs, test.dir)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -161,6 +161,10 @@ type GitBackend interface {
 	// This value can be used to determine if a repository changed since the last
 	// time the hash has been computed.
 	RefHash(ctx context.Context) ([]byte, error)
+
+	// UploadPack returns a git-upload-pack stream for the given repository.
+	// This can be used to expose the Git HTTP smart protocol over HTTP.
+	UploadPack(ctx context.Context, input io.Reader, protocol string, advertiseRefs bool) (io.ReadCloser, error)
 }
 
 type GitDiffComparisonType int

--- a/cmd/gitserver/internal/integration_tests/gitservice_test.go
+++ b/cmd/gitserver/internal/integration_tests/gitservice_test.go
@@ -1,0 +1,107 @@
+package inttests
+
+import (
+	"bytes"
+	"fmt"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/lib/gitservice"
+)
+
+// numTestCommits determines the number of files/commits/tags to create for
+// the local test repo. The value of 25 causes clonev1 and clonev2 to use gzip
+// compression but shallow to be uncompressed. The value of 10 does not trigger
+// this same behavior.
+const numTestCommits = 25
+
+func TestGitUploadPack(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "testrepo")
+
+	// Setup a repo with a commit so we can add bad refs
+	runCmd(t, root, "git", "init", repo)
+
+	for i := range numTestCommits {
+		runCmd(t, repo, "sh", "-c", fmt.Sprintf("echo hello world > hello-%d.txt", i+1))
+		runCmd(t, repo, "git", "add", fmt.Sprintf("hello-%d.txt", i+1))
+		runCmd(t, repo, "git", "commit", "-m", fmt.Sprintf("c%d", i+1))
+		runCmd(t, repo, "git", "tag", fmt.Sprintf("v%d", i+1))
+	}
+
+	ts := httptest.NewServer(&gitservice.Handler{
+		Dir: func(s string) string {
+			return filepath.Join(root, s, ".git")
+		},
+	})
+	defer ts.Close()
+
+	t.Run("404", func(t *testing.T) {
+		c := exec.Command("git", "clone", ts.URL+"/doesnotexist")
+		c.Dir = t.TempDir()
+		b, err := c.CombinedOutput()
+		if !bytes.Contains(b, []byte("repository not found")) {
+			t.Fatal("expected clone to fail with repository not found", string(b), err)
+		}
+	})
+
+	cloneURL := ts.URL + "/testrepo"
+
+	t.Run("clonev1", func(t *testing.T) {
+		runCmd(t, t.TempDir(), "git", "-c", "protocol.version=1", "clone", cloneURL)
+	})
+
+	cloneV2 := []struct {
+		Name string
+		Args []string
+	}{{
+		"clonev2",
+		[]string{},
+	}, {
+		"shallow",
+		[]string{"--depth=1"},
+	}}
+
+	for _, tc := range cloneV2 {
+		t.Run(tc.Name, func(t *testing.T) {
+			args := []string{"-c", "protocol.version=2", "clone"}
+			args = append(args, tc.Args...)
+			args = append(args, cloneURL)
+
+			c := exec.Command("git", args...)
+			c.Dir = t.TempDir()
+			c.Env = []string{
+				"GIT_TRACE_PACKET=1",
+			}
+			b, err := c.CombinedOutput()
+			if err != nil {
+				t.Fatalf("command failed: %s\nOutput: %s", err, b)
+			}
+
+			// This is the same test done by git's tests for checking if the
+			// server is using protocol v2.
+			if !bytes.Contains(b, []byte("git< version 2")) {
+				t.Fatalf("protocol v2 not used by server. Output:\n%s", b)
+			}
+		})
+	}
+}
+
+func runCmd(t *testing.T, dir string, cmd string, arg ...string) {
+	t.Helper()
+	c := exec.Command(cmd, arg...)
+	c.Dir = dir
+	c.Env = []string{
+		"GIT_COMMITTER_NAME=a",
+		"GIT_COMMITTER_EMAIL=a@a.com",
+		"GIT_AUTHOR_NAME=a",
+		"GIT_AUTHOR_EMAIL=a@a.com",
+	}
+	b, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %s\nOutput: %s", cmd, strings.Join(arg, " "), err, b)
+	}
+}

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -159,7 +159,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	internal.RegisterEchoMetric(logger.Scoped("echoMetricReporter"))
 
-	handler := internal.NewHTTPHandler(logger, fs)
+	handler := internal.NewHTTPHandler(logger, fs, backendSource)
 	handler = actor.HTTPMiddleware(logger, handler)
 	handler = requestclient.InternalHTTPMiddleware(handler)
 	handler = requestinteraction.HTTPMiddleware(handler)


### PR DESCRIPTION
This PR reimplements the git upload pack as part of the git CLI, so that we get all the insights and tracking goodies this package comes with.
That will help understand better why we're incurring a lot of IOPS and such.

Test plan:

Integration test for cloning from gitserver.