### PR TITLE
repoupdater: Add metrics around fetch success rate

### DIFF
--- a/cmd/repo-updater/internal/scheduler/metrics.go
+++ b/cmd/repo-updater/internal/scheduler/metrics.go
@@ -30,4 +30,13 @@ var (
 		Name: "src_repoupdater_sched_update_queue_length",
 		Help: "The number of repositories that are currently queued for update",
 	})
+	schedFetchLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "src_repoupdater_sched_latency",
+		Help:    "The time between a last change made upstream and the repo being fetched by the scheduler.",
+		Buckets: prometheus.ExponentialBucketsRange(30, 60*60*24, 20),
+	})
+	schedFetchResult = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "src_repoupdater_sched_fetch_result",
+		Help: "Incremented each time we fetch a repository.",
+	}, []string{"result"})
 )


### PR DESCRIPTION
These metrics will help understand better how many fetches are useful, and how many are
just additional load from polling. It will also help understand how good our metrics
and default settings for the scheduler are, by checking that repos are ideally always
updated soon after a change to said repo was made.

Test plan:

Verified the grafana dashboard works on my local instance.