### PR TITLE
guardrails: enable communicating timeout

### DIFF
--- a/cmd/frontend/graphqlbackend/guardrails.go
+++ b/cmd/frontend/graphqlbackend/guardrails.go
@@ -12,7 +12,8 @@ type GuardrailsResolver interface {
 
 type SnippetAttributionArgs struct {
 	graphqlutil.ConnectionArgs
-	Snippet string
+	Snippet   string
+	TimeoutMs *int32
 }
 
 type SnippetAttributionConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/guardrails.graphql
+++ b/cmd/frontend/graphqlbackend/guardrails.graphql
@@ -2,7 +2,7 @@ extend type Query {
     """
     EXPERIMENTAL: Searches the instances indexed code for code matching snippet.
     """
-    snippetAttribution(snippet: String!, first: Int): SnippetAttributionConnection!
+    snippetAttribution(snippet: String!, first: Int, timeoutMs: Int): SnippetAttributionConnection!
 }
 
 """

--- a/cmd/frontend/internal/guardrails/attribution/attribution_test.go
+++ b/cmd/frontend/internal/guardrails/attribution/attribution_test.go
@@ -30,7 +30,7 @@ func (f fakeGateway) Attribution(ctx context.Context, snippet string, limit int)
 func TestProxySuccess(t *testing.T) {
 	gateway := fakeGateway{}
 	service := NewGatewayProxy(observation.TestContextTB(t), gateway)
-	attribution, err := service.SnippetAttribution(context.Background(), "snippet", 3)
+	attribution, err := service.SnippetAttribution(context.Background(), "snippet", 3, 0)
 	require.NoError(t, err)
 	require.Equal(t, &SnippetAttributions{
 		RepositoryNames: []string{"repo1", "repo2"},
@@ -84,7 +84,7 @@ func TestSearchSuccess(t *testing.T) {
 		repos: []string{"foo1", "bar2"},
 	}
 	service := NewLocalSearch(observation.TestContextTB(t), fs)
-	attribution, err := service.SnippetAttribution(context.Background(), "snippet", 3)
+	attribution, err := service.SnippetAttribution(context.Background(), "snippet", 3, 0)
 	require.NoError(t, err)
 	require.Equal(t, &SnippetAttributions{
 		RepositoryNames: []string{"foo1", "bar2"},

--- a/cmd/frontend/internal/guardrails/init.go
+++ b/cmd/frontend/internal/guardrails/init.go
@@ -114,7 +114,7 @@ func NewAttributionTest(observationCtx *observation.Context, conf conftypes.Site
 			return true, nil
 		}
 		// Attribution not available. Mode is permissive.
-		attribution, err := initLogic.Service().SnippetAttribution(ctx, snippet, 1)
+		attribution, err := initLogic.Service().SnippetAttribution(ctx, snippet, 1, 0)
 		// Attribution not available. Mode is permissive.
 		if err != nil {
 			return true, err

--- a/cmd/frontend/internal/guardrails/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/guardrails/resolvers/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//cmd/frontend/internal/guardrails/attribution",
         "//internal/guardrails",
+        "//lib/pointers",
     ],
 )
 

--- a/cmd/frontend/internal/guardrails/resolvers/resolver.go
+++ b/cmd/frontend/internal/guardrails/resolvers/resolver.go
@@ -3,11 +3,13 @@ package resolvers
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/guardrails/attribution"
 	"github.com/sourcegraph/sourcegraph/internal/guardrails"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 var _ graphqlbackend.GuardrailsResolver = &GuardrailsResolver{}
@@ -45,7 +47,8 @@ func (c *GuardrailsResolver) SnippetAttribution(ctx context.Context, args *graph
 		// snippetThreshold.searchPerformed field within the resolver indicates this case.
 		return snippetAttributionConnectionResolver{}, nil
 	}
-	result, err := c.service().SnippetAttribution(ctx, args.Snippet, limit)
+	timeout := time.Duration(pointers.DerefZero(args.TimeoutMs)) * time.Millisecond
+	result, err := c.service().SnippetAttribution(ctx, args.Snippet, limit, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/guardrails/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/guardrails/resolvers/resolver_test.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -17,7 +18,7 @@ type fakeAttributionService struct {
 	err          error
 }
 
-func (s *fakeAttributionService) SnippetAttribution(ctx context.Context, snippet string, limit int) (result *attribution.SnippetAttributions, err error) {
+func (s *fakeAttributionService) SnippetAttribution(ctx context.Context, snippet string, limit int, timeout time.Duration) (result *attribution.SnippetAttributions, err error) {
 	return &attribution.SnippetAttributions{
 		RepositoryNames: s.searchResult,
 		TotalCount:      len(s.searchResult),


### PR DESCRIPTION
This change allows us to set the timeout field for our search backends when serving a guardrails request.

Right now the guardrails client in Cody times out the HTTP request after 10s. This can lead to hard to understand errors when this happens, since we can't tell if this is a backend problem or something in between.

Test Plan: TODO

Part of CODY-2959
