### PR TITLE
chore(appliance): expose pprof port

### DIFF
--- a/cmd/appliance/shared/config.go
+++ b/cmd/appliance/shared/config.go
@@ -18,6 +18,7 @@ type Config struct {
 
 	k8sConfig              *rest.Config
 	metrics                metricsConfig
+	pprofAddr              string
 	grpc                   grpcConfig
 	http                   httpConfig
 	namespace              string
@@ -43,6 +44,7 @@ func (c *Config) Load() {
 
 	c.k8sConfig = k8sConfig
 	c.metrics.addr = c.Get("APPLIANCE_METRICS_ADDR", ":8734", "Appliance metrics server address.")
+	c.pprofAddr = c.Get("APPLIANCE_PPROF_ADDR", ":6060", "Server on which to expose pprof")
 	c.metrics.secure = c.GetBool("APPLIANCE_METRICS_SECURE", "false", "Appliance metrics server uses https.")
 	c.grpc.addr = c.Get("APPLIANCE_GRPC_ADDR", ":9000", "Appliance gRPC address.")
 	c.http.addr = c.Get("APPLIANCE_HTTP_ADDR", ":8888", "Appliance http address.")

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"strconv"
@@ -129,6 +130,9 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 
 	g, ctx := errgroup.WithContext(ctx)
 	ctx = shutdownOnSignal(ctx)
+
+	// fire-and-forget a pprof server
+	go http.ListenAndServe(config.pprofAddr, nil)
 
 	g.Go(func() error {
 		logger.Info("gRPC server listening", log.String("address", listener.Addr().String()))


### PR DESCRIPTION
We probably don't need to merge this, this is just an illustration of how we might enable pprof. If we do want it, we should probably make it optional.

Relates to https://linear.app/sourcegraph/issue/REL-308/appliance-frontend-seems-to-disconnect-the-backend-during-installation but does not close it.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Manual tire-kicking.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
