### PR TITLE
zoekt: remove Trace option

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6133,8 +6133,8 @@ def go_dependencies():
         patches = [
             "//third_party/com_github_sourcegraph_zoekt:x_defs_version.patch",
         ],
-        sum = "h1:66S/mbdSXfoJT4S4dEEU1ZLZUKwzTfgeTcWZNyI5oA8=",
-        version = "v0.0.0-20240801154129-764fe4f9de0e",
+        sum = "h1:kf3b+ofYN1A/NQ5OhpwArIqEcdfDsHK7LokDwmk8sQY=",
+        version = "v0.0.0-20240802105940-9d583f6b21d1",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -674,7 +674,7 @@ require (
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
-	github.com/sourcegraph/zoekt v0.0.0-20240801154129-764fe4f9de0e
+	github.com/sourcegraph/zoekt v0.0.0-20240802105940-9d583f6b21d1
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2331,8 +2331,8 @@ github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240702160611-15589d6
 github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240702160611-15589d6d8eac/go.mod h1:0bD4781hPFlS2tTcoUERY8aSu/UTA6YQV7Iv2TJvtm8=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240801154129-764fe4f9de0e h1:66S/mbdSXfoJT4S4dEEU1ZLZUKwzTfgeTcWZNyI5oA8=
-github.com/sourcegraph/zoekt v0.0.0-20240801154129-764fe4f9de0e/go.mod h1:bFy43xoeqXhM4vJhIn+w+ehjF/H4iuB/js4cP717jg0=
+github.com/sourcegraph/zoekt v0.0.0-20240802105940-9d583f6b21d1 h1:kf3b+ofYN1A/NQ5OhpwArIqEcdfDsHK7LokDwmk8sQY=
+github.com/sourcegraph/zoekt v0.0.0-20240802105940-9d583f6b21d1/go.mod h1:bFy43xoeqXhM4vJhIn+w+ehjF/H4iuB/js4cP717jg0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/BUILD.bazel
+++ b/internal/search/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//internal/search/streaming/http",
         "//internal/searcher/protocol",
         "//internal/trace",
-        "//internal/trace/policy",
         "//internal/types",
         "//lib/errors",
         "//schema",

--- a/internal/search/symbol/BUILD.bazel
+++ b/internal/search/symbol/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//internal/search/result",
         "//internal/search/zoektquery",
         "//internal/symbols",
-        "//internal/trace/policy",
         "//internal/types",
         "//lib/errors",
         "@com_github_grafana_regexp//:regexp",

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoektquery"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
-	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -237,7 +236,6 @@ func searchZoekt(
 	final := query.Simplify(query.NewAnd(ands...))
 	match := limitOrDefault(first) + 1
 	resp, err := z.Search(ctx, final, &zoekt.SearchOptions{
-		Trace:              policy.ShouldTrace(ctx),
 		MaxWallTime:        3 * time.Second,
 		ShardMaxMatchCount: match * 25,
 		TotalMaxMatchCount: match * 25,

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/searcher/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -185,7 +184,6 @@ func (o *ZoektParameters) ToSearchOptions(ctx context.Context) (searchOpts *zoek
 
 	defaultTimeout := 20 * time.Second
 	searchOpts = &zoekt.SearchOptions{
-		Trace:           policy.ShouldTrace(ctx),
 		MaxWallTime:     defaultTimeout,
 		ChunkMatches:    true,
 		UseBM25Scoring:  o.PatternType == query.SearchTypeCodyContext && o.Typ == TextRequest,


### PR DESCRIPTION
We should just rely on what grpc sends over the wire. Incorporates https://github.com/sourcegraph/zoekt/pull/761
