### PR TITLE
fix/lib/background: always allow goroutine Stop to be called

### DIFF
--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -895,7 +895,7 @@ func TestSyncerMultipleServices(t *testing.T) {
 				DequeueInterval: 1 * time.Millisecond,
 			})...,
 		)
-		assert.EqualError(t, err, "unable to stop routines gracefully: context canceled")
+		assert.NoError(t, err)
 		done <- struct{}{}
 	}()
 


### PR DESCRIPTION
This change aims to address a flaky test reported by https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1722574872063049. I confirmed that the flaky behaviour was introduced by https://github.com/sourcegraph/sourcegraph/pull/62136, as before that change, the same test did not exhibit any flaky behaviour.

In https://github.com/sourcegraph/sourcegraph/pull/62136, the ability to respect context cancellations in background routine `Stop()` was introduced. A roughly equivalent behaviour was added to the multiple routine stopper, where we would wait for the first of the following to occur after we spawn goroutines to Stop each background routine:

1. All stops complete
2. Context is done

However, 2 can happen before we even call `Stop()` on each background routine, which causes the flaky behaviour in tests: if we cancel the context, we lose the ability to know when `Stop()` was called to run our assertions.

IMO the way this behaves is somewhat incorrect: each `Stop()` implementation should decide how to respect cancellation itself. We should always call each `Stop()` implementation, and only give up after context timeout.

This change makes it so that we wait specifically for the context timeout only before giving up on background routine Stops.

> [!NOTE]
> I'm not 100% sure this is the best and only way to fix the unpredictable behaviour, I just pondered this for about an hour and decided this was probably the best way - open to ideas or suggestions!

## Test plan

```
go test -count 1000 -run ^TestMonitorBackgroundRoutinesContextCancel$ github.com/sourcegraph/sourcegraph/lib/background
```

```
go test github.com/sourcegraph/sourcegraph/lib/background
```