### PR TITLE
worker: introduce ctx to NewResetter

### DIFF
--- a/cmd/precise-code-intel-worker/shared/shared.go
+++ b/cmd/precise-code-intel-worker/shared/shared.go
@@ -75,6 +75,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	// Initialize worker
 	worker := uploads.NewUploadProcessorJob(
+		ctx,
 		observationCtx,
 		services.UploadsService,
 		db,

--- a/cmd/worker/internal/authz/perms_syncer_job.go
+++ b/cmd/worker/internal/authz/perms_syncer_job.go
@@ -62,7 +62,7 @@ func (j *permsSyncerJob) Routines(_ context.Context, observationCtx *observation
 		makeWorker(workCtx, observationCtx, userWorkerStore, permsSyncer, syncTypeUser, permissionSyncJobStore),
 		// Type of store (repo/user) for resetter doesn't matter, because it has its
 		// separate name for logging and metrics.
-		makeResetter(observationCtx, repoWorkerStore),
+		makeResetter(workCtx, observationCtx, repoWorkerStore),
 	}
 
 	return routines, nil

--- a/cmd/worker/internal/authz/perms_syncer_worker.go
+++ b/cmd/worker/internal/authz/perms_syncer_worker.go
@@ -159,8 +159,8 @@ func makeWorker(ctx context.Context, observationCtx *observation.Context, worker
 	})
 }
 
-func makeResetter(observationCtx *observation.Context, workerStore dbworkerstore.Store[*database.PermissionSyncJob]) *dbworker.Resetter[*database.PermissionSyncJob] {
-	return dbworker.NewResetter(observationCtx.Logger, workerStore, dbworker.ResetterOptions{
+func makeResetter(ctx context.Context, observationCtx *observation.Context, workerStore dbworkerstore.Store[*database.PermissionSyncJob]) *dbworker.Resetter[*database.PermissionSyncJob] {
+	return dbworker.NewResetter(ctx, observationCtx.Logger, workerStore, dbworker.ResetterOptions{
 		Name:     "permissions_sync_job_worker_resetter",
 		Interval: time.Second * 30, // Check for orphaned jobs every 30 seconds
 		Metrics:  dbworker.NewResetterMetrics(observationCtx, "permissions_sync_job_worker"),

--- a/cmd/worker/internal/batches/janitor/resetters.go
+++ b/cmd/worker/internal/batches/janitor/resetters.go
@@ -1,6 +1,7 @@
 package janitor
 
 import (
+	"context"
 	"time"
 
 	"github.com/sourcegraph/log"
@@ -10,50 +11,50 @@ import (
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
-func NewReconcilerWorkerResetter(logger log.Logger, workerStore dbworkerstore.Store[*types.Changeset], metrics *metrics) *dbworker.Resetter[*types.Changeset] {
+func NewReconcilerWorkerResetter(ctx context.Context, logger log.Logger, workerStore dbworkerstore.Store[*types.Changeset], metrics *metrics) *dbworker.Resetter[*types.Changeset] {
 	options := dbworker.ResetterOptions{
 		Name:     "batches_reconciler_worker_resetter",
 		Interval: 1 * time.Minute,
 		Metrics:  metrics.reconcilerWorkerResetterMetrics,
 	}
 
-	resetter := dbworker.NewResetter(logger, workerStore, options)
+	resetter := dbworker.NewResetter(ctx, logger, workerStore, options)
 	return resetter
 }
 
 // NewBulkOperationWorkerResetter creates a dbworker.Resetter that reenqueues lost jobs
 // for processing.
-func NewBulkOperationWorkerResetter(logger log.Logger, workerStore dbworkerstore.Store[*types.ChangesetJob], metrics *metrics) *dbworker.Resetter[*types.ChangesetJob] {
+func NewBulkOperationWorkerResetter(ctx context.Context, logger log.Logger, workerStore dbworkerstore.Store[*types.ChangesetJob], metrics *metrics) *dbworker.Resetter[*types.ChangesetJob] {
 	options := dbworker.ResetterOptions{
 		Name:     "batches_bulk_worker_resetter",
 		Interval: 1 * time.Minute,
 		Metrics:  metrics.bulkProcessorWorkerResetterMetrics,
 	}
 
-	resetter := dbworker.NewResetter(logger, workerStore, options)
+	resetter := dbworker.NewResetter(ctx, logger, workerStore, options)
 	return resetter
 }
 
 // NewBatchSpecWorkspaceExecutionWorkerResetter creates a dbworker.Resetter that re-enqueues
 // lost batch_spec_workspace_execution_jobs for processing.
-func NewBatchSpecWorkspaceExecutionWorkerResetter(logger log.Logger, workerStore dbworkerstore.Store[*types.BatchSpecWorkspaceExecutionJob], metrics *metrics) *dbworker.Resetter[*types.BatchSpecWorkspaceExecutionJob] {
+func NewBatchSpecWorkspaceExecutionWorkerResetter(ctx context.Context, logger log.Logger, workerStore dbworkerstore.Store[*types.BatchSpecWorkspaceExecutionJob], metrics *metrics) *dbworker.Resetter[*types.BatchSpecWorkspaceExecutionJob] {
 	options := dbworker.ResetterOptions{
 		Name:     "batch_spec_workspace_execution_worker_resetter",
 		Interval: 1 * time.Minute,
 		Metrics:  metrics.batchSpecWorkspaceExecutionWorkerResetterMetrics,
 	}
 
-	resetter := dbworker.NewResetter(logger, workerStore, options)
+	resetter := dbworker.NewResetter(ctx, logger, workerStore, options)
 	return resetter
 }
 
-func NewBatchSpecWorkspaceResolutionWorkerResetter(logger log.Logger, workerStore dbworkerstore.Store[*types.BatchSpecResolutionJob], metrics *metrics) *dbworker.Resetter[*types.BatchSpecResolutionJob] {
+func NewBatchSpecWorkspaceResolutionWorkerResetter(ctx context.Context, logger log.Logger, workerStore dbworkerstore.Store[*types.BatchSpecResolutionJob], metrics *metrics) *dbworker.Resetter[*types.BatchSpecResolutionJob] {
 	options := dbworker.ResetterOptions{
 		Name:     "batch_changes_batch_spec_resolution_worker_resetter",
 		Interval: 1 * time.Minute,
 		Metrics:  metrics.batchSpecResolutionWorkerResetterMetrics,
 	}
 
-	resetter := dbworker.NewResetter(logger, workerStore, options)
+	resetter := dbworker.NewResetter(ctx, logger, workerStore, options)
 	return resetter
 }

--- a/cmd/worker/internal/batches/janitor_job.go
+++ b/cmd/worker/internal/batches/janitor_job.go
@@ -67,21 +67,25 @@ func (j *janitorJob) Routines(_ context.Context, observationCtx *observation.Con
 		executorMetricsReporter,
 
 		janitor.NewReconcilerWorkerResetter(
+			workCtx,
 			observationCtx.Logger.Scoped("ReconcilerWorkerResetter"),
 			reconcilerStore,
 			janitorMetrics,
 		),
 		janitor.NewBulkOperationWorkerResetter(
+			workCtx,
 			observationCtx.Logger.Scoped("BulkOperationWorkerResetter"),
 			bulkOperationStore,
 			janitorMetrics,
 		),
 		janitor.NewBatchSpecWorkspaceExecutionWorkerResetter(
+			workCtx,
 			observationCtx.Logger.Scoped("BatchSpecWorkspaceExecutionWorkerResetter"),
 			workspaceExecutionStore,
 			janitorMetrics,
 		),
 		janitor.NewBatchSpecWorkspaceResolutionWorkerResetter(
+			workCtx,
 			observationCtx.Logger.Scoped("BatchSpecWorkspaceResolutionWorkerResetter"),
 			workspaceResolutionStore,
 			janitorMetrics,

--- a/cmd/worker/internal/codeintel/autoindexing_dependencies.go
+++ b/cmd/worker/internal/codeintel/autoindexing_dependencies.go
@@ -28,7 +28,7 @@ func (j *autoindexingDependencyScheduler) Config() []env.Config {
 	}
 }
 
-func (j *autoindexingDependencyScheduler) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *autoindexingDependencyScheduler) Routines(ctx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err
@@ -40,6 +40,7 @@ func (j *autoindexingDependencyScheduler) Routines(_ context.Context, observatio
 	}
 
 	return autoindexing.NewDependencyIndexSchedulers(
+		ctx,
 		observationCtx,
 		db,
 		services.UploadsService,

--- a/cmd/worker/internal/embeddings/repo/janitor.go
+++ b/cmd/worker/internal/embeddings/repo/janitor.go
@@ -28,17 +28,17 @@ func (j *repoEmbeddingJanitorJob) Config() []env.Config {
 	return []env.Config{}
 }
 
-func (j *repoEmbeddingJanitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *repoEmbeddingJanitorJob) Routines(ctx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err
 	}
 	store := repoembeddingsbg.NewRepoEmbeddingJobWorkerStore(observationCtx, db.Handle())
-	return []goroutine.BackgroundRoutine{newRepoEmbeddingJobResetter(observationCtx, store)}, nil
+	return []goroutine.BackgroundRoutine{newRepoEmbeddingJobResetter(ctx, observationCtx, store)}, nil
 }
 
-func newRepoEmbeddingJobResetter(observationCtx *observation.Context, workerStore dbworkerstore.Store[*repoembeddingsbg.RepoEmbeddingJob]) *dbworker.Resetter[*repoembeddingsbg.RepoEmbeddingJob] {
-	return dbworker.NewResetter(observationCtx.Logger, workerStore, dbworker.ResetterOptions{
+func newRepoEmbeddingJobResetter(ctx context.Context, observationCtx *observation.Context, workerStore dbworkerstore.Store[*repoembeddingsbg.RepoEmbeddingJob]) *dbworker.Resetter[*repoembeddingsbg.RepoEmbeddingJob] {
+	return dbworker.NewResetter(ctx, observationCtx.Logger, workerStore, dbworker.ResetterOptions{
 		Name:     "repo_embedding_job_worker_resetter",
 		Interval: time.Minute, // Check for orphaned jobs every minute
 		Metrics:  dbworker.NewResetterMetrics(observationCtx, "repo_embedding_job_worker"),

--- a/cmd/worker/internal/search/exhaustive_search.go
+++ b/cmd/worker/internal/search/exhaustive_search.go
@@ -86,6 +86,7 @@ func (h *exhaustiveSearchHandler) Handle(ctx context.Context, logger log.Logger,
 }
 
 func newExhaustiveSearchWorkerResetter(
+	ctx context.Context,
 	observationCtx *observation.Context,
 	workerStore dbworkerstore.Store[*types.ExhaustiveSearchJob],
 ) *dbworker.Resetter[*types.ExhaustiveSearchJob] {
@@ -95,6 +96,6 @@ func newExhaustiveSearchWorkerResetter(
 		Metrics:  dbworker.NewResetterMetrics(observationCtx, "exhaustive_search_worker"),
 	}
 
-	resetter := dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	resetter := dbworker.NewResetter(ctx, observationCtx.Logger, workerStore, options)
 	return resetter
 }

--- a/cmd/worker/internal/search/exhaustive_search_repo.go
+++ b/cmd/worker/internal/search/exhaustive_search_repo.go
@@ -96,6 +96,7 @@ func (h *exhaustiveSearchRepoHandler) Handle(ctx context.Context, logger log.Log
 }
 
 func newExhaustiveSearchRepoWorkerResetter(
+	ctx context.Context,
 	observationCtx *observation.Context,
 	workerStore dbworkerstore.Store[*types.ExhaustiveSearchRepoJob],
 ) *dbworker.Resetter[*types.ExhaustiveSearchRepoJob] {
@@ -105,6 +106,6 @@ func newExhaustiveSearchRepoWorkerResetter(
 		Metrics:  dbworker.NewResetterMetrics(observationCtx, "exhaustive_search_repo_worker"),
 	}
 
-	resetter := dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	resetter := dbworker.NewResetter(ctx, observationCtx.Logger, workerStore, options)
 	return resetter
 }

--- a/cmd/worker/internal/search/exhaustive_search_repo_revision.go
+++ b/cmd/worker/internal/search/exhaustive_search_repo_revision.go
@@ -86,6 +86,7 @@ func (h *exhaustiveSearchRepoRevHandler) Handle(ctx context.Context, logger log.
 }
 
 func newExhaustiveSearchRepoRevisionWorkerResetter(
+	ctx context.Context,
 	observationCtx *observation.Context,
 	workerStore dbworkerstore.Store[*types.ExhaustiveSearchRepoRevisionJob],
 ) *dbworker.Resetter[*types.ExhaustiveSearchRepoRevisionJob] {
@@ -95,6 +96,6 @@ func newExhaustiveSearchRepoRevisionWorkerResetter(
 		Metrics:  dbworker.NewResetterMetrics(observationCtx, "exhaustive_search_repo_revision_worker"),
 	}
 
-	resetter := dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	resetter := dbworker.NewResetter(ctx, observationCtx.Logger, workerStore, options)
 	return resetter
 }

--- a/cmd/worker/internal/search/job.go
+++ b/cmd/worker/internal/search/job.go
@@ -122,9 +122,9 @@ func (j *searchJob) newSearchJobRoutines(
 			newExhaustiveSearchRepoRevisionWorker(workCtx, observationCtx, revWorkerStore, exhaustiveSearchStore, newSearcher, uploadStore, j.config),
 
 			// resetters
-			newExhaustiveSearchWorkerResetter(observationCtx, searchWorkerStore),
-			newExhaustiveSearchRepoWorkerResetter(observationCtx, repoWorkerStore),
-			newExhaustiveSearchRepoRevisionWorkerResetter(observationCtx, revWorkerStore),
+			newExhaustiveSearchWorkerResetter(workCtx, observationCtx, searchWorkerStore),
+			newExhaustiveSearchRepoWorkerResetter(workCtx, observationCtx, repoWorkerStore),
+			newExhaustiveSearchRepoRevisionWorkerResetter(workCtx, observationCtx, revWorkerStore),
 
 			newJanitorJob(observationCtx, db, svc),
 		}

--- a/internal/codeintel/autoindexing/init.go
+++ b/internal/codeintel/autoindexing/init.go
@@ -1,6 +1,8 @@
 package autoindexing
 
 import (
+	"context"
+
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/background"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/background/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/background/scheduler"
@@ -67,6 +69,7 @@ func NewIndexSchedulers(
 }
 
 func NewDependencyIndexSchedulers(
+	ctx context.Context,
 	observationCtx *observation.Context,
 	db database.DB,
 	uploadSvc UploadService,
@@ -74,6 +77,7 @@ func NewDependencyIndexSchedulers(
 	autoindexingSvc *Service,
 ) []goroutine.BackgroundRoutine {
 	return background.NewDependencyIndexSchedulers(
+		ctx,
 		scopedContext("dependencies", observationCtx),
 		db,
 		uploadSvc,

--- a/internal/codeintel/autoindexing/internal/background/dependencies/job_resetters.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/job_resetters.go
@@ -1,6 +1,7 @@
 package dependencies
 
 import (
+	"context"
 	"time"
 
 	"github.com/sourcegraph/log"
@@ -13,8 +14,8 @@ import (
 // NewIndexResetter returns a background routine that periodically resets index
 // records that are marked as being processed but are no longer being processed
 // by a worker.
-func NewIndexResetter(logger log.Logger, interval time.Duration, store dbworkerstore.Store[uploadsshared.AutoIndexJob], metrics *resetterMetrics) *dbworker.Resetter[uploadsshared.AutoIndexJob] {
-	return dbworker.NewResetter(logger.Scoped("indexResetter"), store, dbworker.ResetterOptions{
+func NewIndexResetter(ctx context.Context, logger log.Logger, interval time.Duration, store dbworkerstore.Store[uploadsshared.AutoIndexJob], metrics *resetterMetrics) *dbworker.Resetter[uploadsshared.AutoIndexJob] {
+	return dbworker.NewResetter(ctx, logger.Scoped("indexResetter"), store, dbworker.ResetterOptions{
 		Name:     "precise_code_intel_index_worker_resetter",
 		Interval: interval,
 		Metrics: dbworker.ResetterMetrics{
@@ -28,8 +29,8 @@ func NewIndexResetter(logger log.Logger, interval time.Duration, store dbworkers
 // NewDependencyIndexResetter returns a background routine that periodically resets
 // dependency index records that are marked as being processed but are no longer being
 // processed by a worker.
-func NewDependencyIndexResetter(logger log.Logger, interval time.Duration, store dbworkerstore.Store[dependencyIndexingJob], metrics *resetterMetrics) *dbworker.Resetter[dependencyIndexingJob] {
-	return dbworker.NewResetter(logger.Scoped("dependencyIndexResetter"), store, dbworker.ResetterOptions{
+func NewDependencyIndexResetter(ctx context.Context, logger log.Logger, interval time.Duration, store dbworkerstore.Store[dependencyIndexingJob], metrics *resetterMetrics) *dbworker.Resetter[dependencyIndexingJob] {
+	return dbworker.NewResetter(ctx, logger.Scoped("dependencyIndexResetter"), store, dbworker.ResetterOptions{
 		Name:     "precise_code_intel_dependency_index_worker_resetter",
 		Interval: interval,
 		Metrics: dbworker.ResetterMetrics{

--- a/internal/codeintel/autoindexing/internal/background/init.go
+++ b/internal/codeintel/autoindexing/internal/background/init.go
@@ -1,6 +1,8 @@
 package background
 
 import (
+	"context"
+
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/background/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/background/scheduler"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/background/summary"
@@ -50,6 +52,7 @@ func NewIndexSchedulers(
 }
 
 func NewDependencyIndexSchedulers(
+	ctx context.Context,
 	observationCtx *observation.Context,
 	db database.DB,
 	uploadSvc dependencies.UploadService,
@@ -88,8 +91,8 @@ func NewDependencyIndexSchedulers(
 			config,
 		),
 
-		dependencies.NewIndexResetter(observationCtx.Logger.Scoped("indexResetter"), config.ResetterInterval, indexStore, metrics),
-		dependencies.NewDependencyIndexResetter(observationCtx.Logger.Scoped("dependencyIndexResetter"), config.ResetterInterval, dependencyIndexingStore, metrics),
+		dependencies.NewIndexResetter(ctx, observationCtx.Logger.Scoped("indexResetter"), config.ResetterInterval, indexStore, metrics),
+		dependencies.NewDependencyIndexResetter(ctx, observationCtx.Logger.Scoped("dependencyIndexResetter"), config.ResetterInterval, dependencyIndexingStore, metrics),
 	}
 }
 

--- a/internal/codeintel/uploads/init.go
+++ b/internal/codeintel/uploads/init.go
@@ -1,6 +1,7 @@
 package uploads
 
 import (
+	"context"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -50,6 +51,7 @@ var (
 )
 
 func NewUploadProcessorJob(
+	ctx context.Context,
 	observationCtx *observation.Context,
 	uploadSvc *Service,
 	db database.DB,
@@ -65,6 +67,7 @@ func NewUploadProcessorJob(
 	ProcessorConfigInst.MaximumRuntimePerJob = maximumRuntimePerJob
 
 	return background.NewUploadProcessorJob(
+		ctx,
 		scopedContext("processor", observationCtx),
 		uploadSvc.store,
 		uploadSvc.codeGraphDataStore,

--- a/internal/codeintel/uploads/internal/background/init.go
+++ b/internal/codeintel/uploads/internal/background/init.go
@@ -1,6 +1,7 @@
 package background
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -23,6 +24,7 @@ import (
 )
 
 func NewUploadProcessorJob(
+	ctx context.Context,
 	observationCtx *observation.Context,
 	store uploadsstore.Store,
 	dataStore codegraph.DataStore,
@@ -48,7 +50,7 @@ func NewUploadProcessorJob(
 			uploadStore,
 			config,
 		),
-		processor.NewUploadResetter(observationCtx.Logger, uploadsResetterStore, metrics),
+		processor.NewUploadResetter(ctx, observationCtx.Logger, uploadsResetterStore, metrics),
 	}
 }
 

--- a/internal/codeintel/uploads/internal/background/processor/job_resetters.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_resetters.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"context"
 	"time"
 
 	"github.com/sourcegraph/log"
@@ -13,8 +14,8 @@ import (
 // NewUploadResetter returns a background routine that periodically resets upload
 // records that are marked as being processed but are no longer being processed
 // by a worker.
-func NewUploadResetter(logger log.Logger, store store.Store[shared.Upload], metrics *resetterMetrics) *dbworker.Resetter[shared.Upload] {
-	return dbworker.NewResetter(logger.Scoped("uploadResetter"), store, dbworker.ResetterOptions{
+func NewUploadResetter(ctx context.Context, logger log.Logger, store store.Store[shared.Upload], metrics *resetterMetrics) *dbworker.Resetter[shared.Upload] {
+	return dbworker.NewResetter(ctx, logger.Scoped("uploadResetter"), store, dbworker.ResetterOptions{
 		Name:     "precise_code_intel_upload_worker_resetter",
 		Interval: 30 * time.Second,
 		Metrics: dbworker.ResetterMetrics{

--- a/internal/codemonitors/background/workers.go
+++ b/internal/codemonitors/background/workers.go
@@ -62,7 +62,7 @@ func newTriggerQueryEnqueuer(ctx context.Context, store database.CodeMonitorStor
 	)
 }
 
-func newTriggerQueryResetter(_ context.Context, observationCtx *observation.Context, s database.CodeMonitorStore, metrics codeMonitorsMetrics) *dbworker.Resetter[*database.TriggerJob] {
+func newTriggerQueryResetter(ctx context.Context, observationCtx *observation.Context, s database.CodeMonitorStore, metrics codeMonitorsMetrics) *dbworker.Resetter[*database.TriggerJob] {
 	workerStore := createDBWorkerStoreForTriggerJobs(observationCtx, s)
 
 	options := dbworker.ResetterOptions{
@@ -74,7 +74,7 @@ func newTriggerQueryResetter(_ context.Context, observationCtx *observation.Cont
 			RecordResets:        metrics.resets,
 		},
 	}
-	return dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	return dbworker.NewResetter(ctx, observationCtx.Logger, workerStore, options)
 }
 
 func newTriggerJobsLogDeleter(ctx context.Context, store database.CodeMonitorStore) goroutine.BackgroundRoutine {
@@ -107,7 +107,7 @@ func newActionRunner(ctx context.Context, observationCtx *observation.Context, s
 	return worker
 }
 
-func newActionJobResetter(_ context.Context, observationCtx *observation.Context, s database.CodeMonitorStore, metrics codeMonitorsMetrics) *dbworker.Resetter[*database.ActionJob] {
+func newActionJobResetter(ctx context.Context, observationCtx *observation.Context, s database.CodeMonitorStore, metrics codeMonitorsMetrics) *dbworker.Resetter[*database.ActionJob] {
 	workerStore := createDBWorkerStoreForActionJobs(observationCtx, s)
 
 	options := dbworker.ResetterOptions{
@@ -119,7 +119,7 @@ func newActionJobResetter(_ context.Context, observationCtx *observation.Context
 			RecordResets:        metrics.resets,
 		},
 	}
-	return dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	return dbworker.NewResetter(ctx, observationCtx.Logger, workerStore, options)
 }
 
 func createDBWorkerStoreForTriggerJobs(observationCtx *observation.Context, s basestore.ShareableStore) dbworkerstore.Store[*database.TriggerJob] {

--- a/internal/insights/background/queryrunner/worker.go
+++ b/internal/insights/background/queryrunner/worker.go
@@ -89,7 +89,7 @@ func NewResetter(ctx context.Context, logger log.Logger, workerStore dbworkersto
 		Interval: 1 * time.Minute,
 		Metrics:  metrics,
 	}
-	return dbworker.NewResetter(logger, workerStore, options)
+	return dbworker.NewResetter(ctx, logger, workerStore, options)
 }
 
 // CreateDBWorkerStore creates the dbworker store for the query runner worker.

--- a/internal/insights/background/retention/worker.go
+++ b/internal/insights/background/retention/worker.go
@@ -104,7 +104,7 @@ func NewResetter(ctx context.Context, logger log.Logger, workerStore dbworkersto
 		Interval: 1 * time.Minute,
 		Metrics:  metrics,
 	}
-	return dbworker.NewResetter(logger, workerStore, options)
+	return dbworker.NewResetter(ctx, logger, workerStore, options)
 }
 
 func CreateDBWorkerStore(observationCtx *observation.Context, store *basestore.Store) dbworkerstore.Store[*DataRetentionJob] {

--- a/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -75,7 +75,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		Metrics:           workerutil.NewMetrics(config.ObservationCtx, name),
 	})
 
-	resetter := dbworker.NewResetter(log.Scoped("resetter"), workerStore, dbworker.ResetterOptions{
+	resetter := dbworker.NewResetter(ctx, log.Scoped("resetter"), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
 		Metrics:  dbworker.NewResetterMetrics(config.ObservationCtx, name),

--- a/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/internal/insights/scheduler/backfill_state_new_handler.go
@@ -75,7 +75,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 		Metrics:           workerutil.NewMetrics(config.ObservationCtx, name),
 	})
 
-	resetter := dbworker.NewResetter(log.Scoped("BackfillNewResetter"), workerStore, dbworker.ResetterOptions{
+	resetter := dbworker.NewResetter(ctx, log.Scoped("BackfillNewResetter"), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
 		Metrics:  dbworker.NewResetterMetrics(config.ObservationCtx, name),

--- a/internal/own/background/background.go
+++ b/internal/own/background/background.go
@@ -158,7 +158,7 @@ func makeWorker(ctx context.Context, db database.DB, observationCtx *observation
 		Metrics:           workerutil.NewMetrics(observationCtx, "own_background_worker_processor"),
 	})
 
-	resetter := dbworker.NewResetter(log.Scoped("OwnBackgroundResetter"), workerStore, dbworker.ResetterOptions{
+	resetter := dbworker.NewResetter(ctx, log.Scoped("OwnBackgroundResetter"), workerStore, dbworker.ResetterOptions{
 		Name:     "own_background_worker_resetter",
 		Interval: time.Second * 20,
 		Metrics:  dbworker.NewResetterMetrics(observationCtx, "own_background_worker"),

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -80,7 +80,7 @@ func NewSyncWorker(ctx context.Context, observationCtx *observation.Context, dbH
 		Metrics:           newWorkerMetrics(observationCtx),
 	})
 
-	resetter := dbworker.NewResetter(observationCtx.Logger.Scoped("repo.sync.worker.Resetter"), store, dbworker.ResetterOptions{
+	resetter := dbworker.NewResetter(ctx, observationCtx.Logger.Scoped("repo.sync.worker.Resetter"), store, dbworker.ResetterOptions{
 		Name:     "repo_sync_worker_resetter",
 		Interval: 5 * time.Minute,
 		Metrics:  newResetterMetrics(observationCtx),

--- a/internal/workerutil/dbworker/resetter_test.go
+++ b/internal/workerutil/dbworker/resetter_test.go
@@ -29,6 +29,7 @@ func (v TestRecord) RecordUID() string {
 }
 
 func TestResetter(t *testing.T) {
+	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	s := storemocks.NewMockStore[*TestRecord]()
 	clock := glock.NewMockClock()
@@ -42,7 +43,7 @@ func TestResetter(t *testing.T) {
 		},
 	}
 
-	resetter := newResetter(logger, store.Store[*TestRecord](s), options, clock)
+	resetter := newResetter(ctx, logger, store.Store[*TestRecord](s), options, clock)
 	go func() { resetter.Start() }()
 	clock.BlockingAdvance(time.Second)
 	err := resetter.Stop(context.Background())


### PR DESCRIPTION
This was directly creating a context.Background(), but we have context's "from above" that should be used and respected. Generally these contexts are the context from "func main" or the ctx passed into the Routine call. For some reason these where nearly always ignored, which I believe is just due to how people do copy paste when creating a new worker.

I read a bit of code to make sure this was correct (but will have to rely on real life testing as well). The most interesting case was how we start up routines concurrently. Before we ignore ctx most of the time => if a job failed we didn't shut down quickly. Now we do.

Minor: I also made the Stop implementation respect the passed in context. From reading usages of ctx and finished this change is correct.

Test Plan: lots of reading of code, otherwise will rely on our tests and how this behaves on S2. I will only land this change after the release tomorrow.