### PR TITLE
Redis: add context arg for list methods

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/diagnostics.go
+++ b/cmd/cody-gateway/internal/httpapi/diagnostics.go
@@ -110,5 +110,5 @@ func NewDiagnosticsHandler(baseLogger log.Logger, next http.Handler, redisCache 
 }
 
 func healthz(ctx context.Context, cache redispool.KeyValue) error {
-	return cache.WithContext(ctx).Ping()
+	return cache.Ping(ctx)
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -173,7 +173,7 @@ func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, oper
 				Errors:    errFields,
 				Query:     queryString,
 			}
-			captureSlowRequest(t.logger, req)
+			captureSlowRequest(ctx, t.logger, req)
 		}
 	}
 }

--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -51,7 +51,7 @@ func (r *RepositoryResolver) RecordedCommands(ctx context.Context, args *Recorde
 		return gqlutil.NewSliceConnectionResolver([]RecordedCommandResolver{}, 0, currentEnd), nil
 	}
 	store := rcache.NewFIFOList(redispool.Cache, wrexec.GetFIFOListKey(r.Name()), recordingConf.Size)
-	empty, err := store.IsEmpty()
+	empty, err := store.IsEmpty(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (r *RepositoryResolver) RecordedCommands(ctx context.Context, args *Recorde
 		return nil, err
 	}
 
-	size, err := store.Size()
+	size, err := store.Size(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/recorded_commands_test.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands_test.go
@@ -145,7 +145,7 @@ func TestRecordedCommandsResolver(t *testing.T) {
 			Dir:      "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
 			Path:     "/opt/homebrew/bin/git",
 		}
-		err = r.Insert(marshalCmd(t, cmd1))
+		err = r.Insert(ctx, marshalCmd(t, cmd1))
 		require.NoError(t, err)
 
 		RunTest(t, &Test{
@@ -227,11 +227,11 @@ func TestRecordedCommandsResolver(t *testing.T) {
 
 		r := rcache.NewFIFOList(kv, wrexec.GetFIFOListKey(repoName), 3)
 
-		err = r.Insert(marshalCmd(t, cmd1))
+		err = r.Insert(ctx, marshalCmd(t, cmd1))
 		require.NoError(t, err)
-		err = r.Insert(marshalCmd(t, cmd2))
+		err = r.Insert(ctx, marshalCmd(t, cmd2))
 		require.NoError(t, err)
-		err = r.Insert(marshalCmd(t, cmd3))
+		err = r.Insert(ctx, marshalCmd(t, cmd3))
 		require.NoError(t, err)
 
 		t.Run("limit within bounds", func(t *testing.T) {
@@ -525,7 +525,7 @@ func TestRecordedCommandsResolver(t *testing.T) {
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
 					Message: "must be site admin",
-					Path:    []any{string("repository"), string("recordedCommands")},
+					Path:    []any{"repository", "recordedCommands"},
 				},
 			},
 		})

--- a/cmd/frontend/graphqlbackend/slow_requests_tracer.go
+++ b/cmd/frontend/graphqlbackend/slow_requests_tracer.go
@@ -35,7 +35,8 @@ func captureSlowRequest(logger log.Logger, req *types.SlowRequest) {
 		logger.Warn("failed to marshal slowRequest", log.Error(err))
 		return
 	}
-	if err := slowRequestRedisFIFOList.Insert(b); err != nil {
+	// TODO(multi-tenant): Remove context.Background()
+	if err := slowRequestRedisFIFOList.Insert(context.Background(), b); err != nil {
 		logger.Warn("failed to capture slowRequest", log.Error(err))
 	}
 }
@@ -111,7 +112,7 @@ func (r *slowRequestConnectionResolver) fetch(ctx context.Context) ([]*types.Slo
 			r.err = err
 		}
 		r.reqs, r.err = getSlowRequestsAfter(ctx, slowRequestRedisFIFOList, n, r.perPage)
-		size, err := slowRequestRedisFIFOList.Size()
+		size, err := slowRequestRedisFIFOList.Size(ctx)
 		if err != nil {
 			r.err = errors.Append(r.err, err)
 		} else {

--- a/cmd/frontend/graphqlbackend/slow_requests_tracer.go
+++ b/cmd/frontend/graphqlbackend/slow_requests_tracer.go
@@ -29,14 +29,13 @@ var slowRequestRedisFIFOList = rcache.NewFIFOListDynamic(redispool.Cache, "slow-
 })
 
 // captureSlowRequest stores in a redis cache slow GraphQL requests.
-func captureSlowRequest(logger log.Logger, req *types.SlowRequest) {
+func captureSlowRequest(ctx context.Context, logger log.Logger, req *types.SlowRequest) {
 	b, err := json.Marshal(req)
 	if err != nil {
 		logger.Warn("failed to marshal slowRequest", log.Error(err))
 		return
 	}
-	// TODO(multi-tenant): Remove context.Background()
-	if err := slowRequestRedisFIFOList.Insert(context.Background(), b); err != nil {
+	if err := slowRequestRedisFIFOList.Insert(ctx, b); err != nil {
 		logger.Warn("failed to capture slowRequest", log.Error(err))
 	}
 }

--- a/cmd/frontend/graphqlbackend/slow_requests_tracer_test.go
+++ b/cmd/frontend/graphqlbackend/slow_requests_tracer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -39,7 +40,7 @@ func Test_captureSlowRequest(t *testing.T) {
 			Errors:    []string{"something"},
 		}
 
-		captureSlowRequest(logger, &req)
+		captureSlowRequest(ctx, logger, &req)
 
 		raws, err := slowRequestRedisFIFOList.All(ctx)
 		if err != nil {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -460,7 +460,7 @@ func waitForRedis(logger sglog.Logger, kv redispool.KeyValue) {
 	var err error
 	for {
 		time.Sleep(150 * time.Millisecond)
-		err = kv.Ping()
+		err = kv.Ping(context.Background())
 		if err == nil {
 			return
 		}

--- a/internal/batches/scheduler/scheduler.go
+++ b/internal/batches/scheduler/scheduler.go
@@ -75,7 +75,7 @@ func (s *Scheduler) Start() {
 
 				duration := time.Since(start)
 				if s.recorder != nil {
-					go s.recorder.LogRun(s, duration, nil)
+					go s.recorder.LogRun(context.Background(), s, duration, nil)
 				}
 
 			case <-validity.C:

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -378,7 +378,7 @@ func (r *PeriodicGoroutine) withRecorder(ctx context.Context, f func(ctx context
 
 	go func() {
 		r.recorder.SaveKnownRoutine(r)
-		r.recorder.LogRun(r, duration, errorFilter(ctx, err))
+		r.recorder.LogRun(ctx, r, duration, errorFilter(ctx, err))
 	}()
 
 	return err

--- a/internal/goroutine/recorder/BUILD.bazel
+++ b/internal/goroutine/recorder/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     deps = [
         "//internal/rcache",
         "//internal/redispool",
+        "//internal/tenant",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@com_github_stretchr_testify//assert",

--- a/internal/goroutine/recorder/common_test.go
+++ b/internal/goroutine/recorder/common_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/tenant"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -19,6 +20,7 @@ func TestLoggerAndReaderHappyPaths(t *testing.T) {
 
 	// Create logger
 	c := rcache.NewWithTTL(redispool.Cache, keyPrefix, 1)
+	ctx := tenant.TestContext()
 	recorder := New(log.NoOp(), "test", c)
 
 	// Create routines
@@ -55,11 +57,11 @@ func TestLoggerAndReaderHappyPaths(t *testing.T) {
 	recorder.LogStart(routine1)
 	recorder.LogStart(routine2)
 	recorder.LogStart(routine3)
-	recorder.LogRun(routine1, 10*time.Millisecond, nil)
-	recorder.LogRun(routine1, 20*time.Millisecond, errors.New("test error"))
+	recorder.LogRun(ctx, routine1, 10*time.Millisecond, nil)
+	recorder.LogRun(ctx, routine1, 20*time.Millisecond, errors.New("test error"))
 	for range 100 { // Make sure int32 overflow doesn't happen
-		recorder.LogRun(routine2, 10*time.Hour, nil)
-		recorder.LogRun(routine2, 20*time.Hour, nil)
+		recorder.LogRun(ctx, routine2, 10*time.Hour, nil)
+		recorder.LogRun(ctx, routine2, 20*time.Hour, nil)
 	}
 	recorder.LogStop(routine3)
 

--- a/internal/goroutine/recorder/recorder.go
+++ b/internal/goroutine/recorder/recorder.go
@@ -173,7 +173,8 @@ func (m *Recorder) saveRun(jobName string, routineName string, hostName string, 
 	}
 
 	// Save run
-	err = getRecentRuns(m.rcache, jobName, routineName, hostName).Insert(runJson)
+	// TODO(multi-tenant): Remove context.Background()
+	err = getRecentRuns(m.rcache, jobName, routineName, hostName).Insert(context.Background(), runJson)
 	if err != nil {
 		return errors.Wrap(err, "save run")
 	}

--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -118,7 +118,7 @@ func redisLoggerMiddleware() Middleware {
 
 			go func() {
 				// Save new item
-				if err := outboundRequestsRedisFIFOList.Insert(logItemJson); err != nil {
+				if err := outboundRequestsRedisFIFOList.Insert(req.Context(), logItemJson); err != nil {
 					// Log would get upset if we created a logger at init time → create logger on the fly
 					log.Scoped("redisLoggerMiddleware").Error("insert log item", log.Error(err))
 				}

--- a/internal/ratelimit/BUILD.bazel
+++ b/internal/ratelimit/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//internal/conf",
         "//internal/redispool",
+        "//internal/tenant",
         "//internal/timeutil",
         "//lib/errors",
         "@com_github_gomodule_redigo//redis",

--- a/internal/ratelimit/globallimiter.go
+++ b/internal/ratelimit/globallimiter.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/tenant"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -498,11 +499,12 @@ type TB interface {
 func SetupForTest(t TB) {
 	t.Helper()
 
+	ctx := tenant.TestContext()
 	testStore = redispool.NewTestKeyValue()
 
 	// If we are not on CI, skip the test if our redis connection fails.
 	if os.Getenv("CI") == "" {
-		if err := testStore.Ping(); err != nil {
+		if err := testStore.Ping(ctx); err != nil {
 			t.Skip("could not connect to redis", err)
 		}
 	}

--- a/internal/rcache/BUILD.bazel
+++ b/internal/rcache/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/redispool",
+        "//internal/tenant",
         "//lib/errors",
         "@com_github_gomodule_redigo//redis",
         "@com_github_inconshreveable_log15//:log15",
@@ -30,6 +31,7 @@ go_test(
         "requires-network",
     ],
     deps = [
+        "//internal/tenant",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
 
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/tenant"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -243,6 +244,7 @@ const testAddr = "127.0.0.1:6379"
 func SetupForTest(t testing.TB) redispool.KeyValue {
 	t.Helper()
 
+	ctx := tenant.TestContext()
 	testStore = redispool.NewTestKeyValue()
 	t.Cleanup(func() {
 		testStore.Pool().Close()
@@ -251,7 +253,7 @@ func SetupForTest(t testing.TB) redispool.KeyValue {
 
 	// If we are not on CI, skip the test if our redis connection fails.
 	if os.Getenv("CI") == "" {
-		if err := testStore.Ping(); err != nil {
+		if err := testStore.Ping(ctx); err != nil {
 			t.Skip("could not connect to redis", err)
 		}
 	}

--- a/internal/redispool/BUILD.bazel
+++ b/internal/redispool/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "requires-network",
     ],
     deps = [
+        "//internal/tenant",
         "//lib/errors",
         "@com_github_gomodule_redigo//redis",
         "@com_github_sourcegraph_log//logtest",

--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -303,7 +303,7 @@ func (r *redisKeyValue) doWithoutContext(commandName string, keys []string, args
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return r.do(nil, commandName, keys, args)
+	return r.do(ctx, commandName, keys, args)
 }
 
 func (r *redisKeyValue) do(ctx context.Context, commandName string, keys []string, args []any) Value {

--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -297,7 +297,13 @@ func (r *redisKeyValue) Pool() *redis.Pool {
 }
 
 func (r *redisKeyValue) doWithoutContext(commandName string, keys []string, args []any) Value {
-	return r.do(context.Background(), commandName, keys, args)
+	// Fall back to the context field, or context.Background if it is not set.
+	// Note: we will remove this logic (including r.ctx) once all operations take context directly.
+	ctx := r.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return r.do(nil, commandName, keys, args)
 }
 
 func (r *redisKeyValue) do(ctx context.Context, commandName string, keys []string, args []any) Value {

--- a/internal/redispool/mocks.go
+++ b/internal/redispool/mocks.go
@@ -170,22 +170,22 @@ func NewMockKeyValue() *MockKeyValue {
 			},
 		},
 		LLenFunc: &KeyValueLLenFunc{
-			defaultHook: func(string) (r0 int, r1 error) {
+			defaultHook: func(context.Context, string) (r0 int, r1 error) {
 				return
 			},
 		},
 		LPushFunc: &KeyValueLPushFunc{
-			defaultHook: func(string, interface{}) (r0 error) {
+			defaultHook: func(context.Context, string, interface{}) (r0 error) {
 				return
 			},
 		},
 		LRangeFunc: &KeyValueLRangeFunc{
-			defaultHook: func(string, int, int) (r0 Values) {
+			defaultHook: func(context.Context, string, int, int) (r0 Values) {
 				return
 			},
 		},
 		LTrimFunc: &KeyValueLTrimFunc{
-			defaultHook: func(string, int, int) (r0 error) {
+			defaultHook: func(context.Context, string, int, int) (r0 error) {
 				return
 			},
 		},
@@ -195,7 +195,7 @@ func NewMockKeyValue() *MockKeyValue {
 			},
 		},
 		PingFunc: &KeyValuePingFunc{
-			defaultHook: func() (r0 error) {
+			defaultHook: func(context.Context) (r0 error) {
 				return
 			},
 		},
@@ -312,22 +312,22 @@ func NewStrictMockKeyValue() *MockKeyValue {
 			},
 		},
 		LLenFunc: &KeyValueLLenFunc{
-			defaultHook: func(string) (int, error) {
+			defaultHook: func(context.Context, string) (int, error) {
 				panic("unexpected invocation of MockKeyValue.LLen")
 			},
 		},
 		LPushFunc: &KeyValueLPushFunc{
-			defaultHook: func(string, interface{}) error {
+			defaultHook: func(context.Context, string, interface{}) error {
 				panic("unexpected invocation of MockKeyValue.LPush")
 			},
 		},
 		LRangeFunc: &KeyValueLRangeFunc{
-			defaultHook: func(string, int, int) Values {
+			defaultHook: func(context.Context, string, int, int) Values {
 				panic("unexpected invocation of MockKeyValue.LRange")
 			},
 		},
 		LTrimFunc: &KeyValueLTrimFunc{
-			defaultHook: func(string, int, int) error {
+			defaultHook: func(context.Context, string, int, int) error {
 				panic("unexpected invocation of MockKeyValue.LTrim")
 			},
 		},
@@ -337,7 +337,7 @@ func NewStrictMockKeyValue() *MockKeyValue {
 			},
 		},
 		PingFunc: &KeyValuePingFunc{
-			defaultHook: func() error {
+			defaultHook: func(context.Context) error {
 				panic("unexpected invocation of MockKeyValue.Ping")
 			},
 		},
@@ -1832,23 +1832,23 @@ func (c KeyValueKeysFuncCall) Results() []interface{} {
 // KeyValueLLenFunc describes the behavior when the LLen method of the
 // parent MockKeyValue instance is invoked.
 type KeyValueLLenFunc struct {
-	defaultHook func(string) (int, error)
-	hooks       []func(string) (int, error)
+	defaultHook func(context.Context, string) (int, error)
+	hooks       []func(context.Context, string) (int, error)
 	history     []KeyValueLLenFuncCall
 	mutex       sync.Mutex
 }
 
 // LLen delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockKeyValue) LLen(v0 string) (int, error) {
-	r0, r1 := m.LLenFunc.nextHook()(v0)
-	m.LLenFunc.appendCall(KeyValueLLenFuncCall{v0, r0, r1})
+func (m *MockKeyValue) LLen(v0 context.Context, v1 string) (int, error) {
+	r0, r1 := m.LLenFunc.nextHook()(v0, v1)
+	m.LLenFunc.appendCall(KeyValueLLenFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the LLen method of the
 // parent MockKeyValue instance is invoked and the hook queue is empty.
-func (f *KeyValueLLenFunc) SetDefaultHook(hook func(string) (int, error)) {
+func (f *KeyValueLLenFunc) SetDefaultHook(hook func(context.Context, string) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -1856,7 +1856,7 @@ func (f *KeyValueLLenFunc) SetDefaultHook(hook func(string) (int, error)) {
 // LLen method of the parent MockKeyValue instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *KeyValueLLenFunc) PushHook(hook func(string) (int, error)) {
+func (f *KeyValueLLenFunc) PushHook(hook func(context.Context, string) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1865,19 +1865,19 @@ func (f *KeyValueLLenFunc) PushHook(hook func(string) (int, error)) {
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *KeyValueLLenFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(string) (int, error) {
+	f.SetDefaultHook(func(context.Context, string) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *KeyValueLLenFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(string) (int, error) {
+	f.PushHook(func(context.Context, string) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *KeyValueLLenFunc) nextHook() func(string) (int, error) {
+func (f *KeyValueLLenFunc) nextHook() func(context.Context, string) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1912,7 +1912,10 @@ func (f *KeyValueLLenFunc) History() []KeyValueLLenFuncCall {
 type KeyValueLLenFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 string
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -1924,7 +1927,7 @@ type KeyValueLLenFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c KeyValueLLenFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -1936,23 +1939,23 @@ func (c KeyValueLLenFuncCall) Results() []interface{} {
 // KeyValueLPushFunc describes the behavior when the LPush method of the
 // parent MockKeyValue instance is invoked.
 type KeyValueLPushFunc struct {
-	defaultHook func(string, interface{}) error
-	hooks       []func(string, interface{}) error
+	defaultHook func(context.Context, string, interface{}) error
+	hooks       []func(context.Context, string, interface{}) error
 	history     []KeyValueLPushFuncCall
 	mutex       sync.Mutex
 }
 
 // LPush delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockKeyValue) LPush(v0 string, v1 interface{}) error {
-	r0 := m.LPushFunc.nextHook()(v0, v1)
-	m.LPushFunc.appendCall(KeyValueLPushFuncCall{v0, v1, r0})
+func (m *MockKeyValue) LPush(v0 context.Context, v1 string, v2 interface{}) error {
+	r0 := m.LPushFunc.nextHook()(v0, v1, v2)
+	m.LPushFunc.appendCall(KeyValueLPushFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the LPush method of the
 // parent MockKeyValue instance is invoked and the hook queue is empty.
-func (f *KeyValueLPushFunc) SetDefaultHook(hook func(string, interface{}) error) {
+func (f *KeyValueLPushFunc) SetDefaultHook(hook func(context.Context, string, interface{}) error) {
 	f.defaultHook = hook
 }
 
@@ -1960,7 +1963,7 @@ func (f *KeyValueLPushFunc) SetDefaultHook(hook func(string, interface{}) error)
 // LPush method of the parent MockKeyValue instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *KeyValueLPushFunc) PushHook(hook func(string, interface{}) error) {
+func (f *KeyValueLPushFunc) PushHook(hook func(context.Context, string, interface{}) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1969,19 +1972,19 @@ func (f *KeyValueLPushFunc) PushHook(hook func(string, interface{}) error) {
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *KeyValueLPushFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(string, interface{}) error {
+	f.SetDefaultHook(func(context.Context, string, interface{}) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *KeyValueLPushFunc) PushReturn(r0 error) {
-	f.PushHook(func(string, interface{}) error {
+	f.PushHook(func(context.Context, string, interface{}) error {
 		return r0
 	})
 }
 
-func (f *KeyValueLPushFunc) nextHook() func(string, interface{}) error {
+func (f *KeyValueLPushFunc) nextHook() func(context.Context, string, interface{}) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2016,10 +2019,13 @@ func (f *KeyValueLPushFunc) History() []KeyValueLPushFuncCall {
 type KeyValueLPushFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 string
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 interface{}
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 interface{}
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -2028,7 +2034,7 @@ type KeyValueLPushFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c KeyValueLPushFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2040,23 +2046,23 @@ func (c KeyValueLPushFuncCall) Results() []interface{} {
 // KeyValueLRangeFunc describes the behavior when the LRange method of the
 // parent MockKeyValue instance is invoked.
 type KeyValueLRangeFunc struct {
-	defaultHook func(string, int, int) Values
-	hooks       []func(string, int, int) Values
+	defaultHook func(context.Context, string, int, int) Values
+	hooks       []func(context.Context, string, int, int) Values
 	history     []KeyValueLRangeFuncCall
 	mutex       sync.Mutex
 }
 
 // LRange delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockKeyValue) LRange(v0 string, v1 int, v2 int) Values {
-	r0 := m.LRangeFunc.nextHook()(v0, v1, v2)
-	m.LRangeFunc.appendCall(KeyValueLRangeFuncCall{v0, v1, v2, r0})
+func (m *MockKeyValue) LRange(v0 context.Context, v1 string, v2 int, v3 int) Values {
+	r0 := m.LRangeFunc.nextHook()(v0, v1, v2, v3)
+	m.LRangeFunc.appendCall(KeyValueLRangeFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the LRange method of the
 // parent MockKeyValue instance is invoked and the hook queue is empty.
-func (f *KeyValueLRangeFunc) SetDefaultHook(hook func(string, int, int) Values) {
+func (f *KeyValueLRangeFunc) SetDefaultHook(hook func(context.Context, string, int, int) Values) {
 	f.defaultHook = hook
 }
 
@@ -2064,7 +2070,7 @@ func (f *KeyValueLRangeFunc) SetDefaultHook(hook func(string, int, int) Values) 
 // LRange method of the parent MockKeyValue instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *KeyValueLRangeFunc) PushHook(hook func(string, int, int) Values) {
+func (f *KeyValueLRangeFunc) PushHook(hook func(context.Context, string, int, int) Values) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2073,19 +2079,19 @@ func (f *KeyValueLRangeFunc) PushHook(hook func(string, int, int) Values) {
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *KeyValueLRangeFunc) SetDefaultReturn(r0 Values) {
-	f.SetDefaultHook(func(string, int, int) Values {
+	f.SetDefaultHook(func(context.Context, string, int, int) Values {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *KeyValueLRangeFunc) PushReturn(r0 Values) {
-	f.PushHook(func(string, int, int) Values {
+	f.PushHook(func(context.Context, string, int, int) Values {
 		return r0
 	})
 }
 
-func (f *KeyValueLRangeFunc) nextHook() func(string, int, int) Values {
+func (f *KeyValueLRangeFunc) nextHook() func(context.Context, string, int, int) Values {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2120,13 +2126,16 @@ func (f *KeyValueLRangeFunc) History() []KeyValueLRangeFuncCall {
 type KeyValueLRangeFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 string
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 Values
@@ -2135,7 +2144,7 @@ type KeyValueLRangeFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c KeyValueLRangeFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2147,23 +2156,23 @@ func (c KeyValueLRangeFuncCall) Results() []interface{} {
 // KeyValueLTrimFunc describes the behavior when the LTrim method of the
 // parent MockKeyValue instance is invoked.
 type KeyValueLTrimFunc struct {
-	defaultHook func(string, int, int) error
-	hooks       []func(string, int, int) error
+	defaultHook func(context.Context, string, int, int) error
+	hooks       []func(context.Context, string, int, int) error
 	history     []KeyValueLTrimFuncCall
 	mutex       sync.Mutex
 }
 
 // LTrim delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockKeyValue) LTrim(v0 string, v1 int, v2 int) error {
-	r0 := m.LTrimFunc.nextHook()(v0, v1, v2)
-	m.LTrimFunc.appendCall(KeyValueLTrimFuncCall{v0, v1, v2, r0})
+func (m *MockKeyValue) LTrim(v0 context.Context, v1 string, v2 int, v3 int) error {
+	r0 := m.LTrimFunc.nextHook()(v0, v1, v2, v3)
+	m.LTrimFunc.appendCall(KeyValueLTrimFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the LTrim method of the
 // parent MockKeyValue instance is invoked and the hook queue is empty.
-func (f *KeyValueLTrimFunc) SetDefaultHook(hook func(string, int, int) error) {
+func (f *KeyValueLTrimFunc) SetDefaultHook(hook func(context.Context, string, int, int) error) {
 	f.defaultHook = hook
 }
 
@@ -2171,7 +2180,7 @@ func (f *KeyValueLTrimFunc) SetDefaultHook(hook func(string, int, int) error) {
 // LTrim method of the parent MockKeyValue instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *KeyValueLTrimFunc) PushHook(hook func(string, int, int) error) {
+func (f *KeyValueLTrimFunc) PushHook(hook func(context.Context, string, int, int) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2180,19 +2189,19 @@ func (f *KeyValueLTrimFunc) PushHook(hook func(string, int, int) error) {
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *KeyValueLTrimFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(string, int, int) error {
+	f.SetDefaultHook(func(context.Context, string, int, int) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *KeyValueLTrimFunc) PushReturn(r0 error) {
-	f.PushHook(func(string, int, int) error {
+	f.PushHook(func(context.Context, string, int, int) error {
 		return r0
 	})
 }
 
-func (f *KeyValueLTrimFunc) nextHook() func(string, int, int) error {
+func (f *KeyValueLTrimFunc) nextHook() func(context.Context, string, int, int) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2227,13 +2236,16 @@ func (f *KeyValueLTrimFunc) History() []KeyValueLTrimFuncCall {
 type KeyValueLTrimFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 string
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -2242,7 +2254,7 @@ type KeyValueLTrimFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c KeyValueLTrimFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2355,23 +2367,23 @@ func (c KeyValueMGetFuncCall) Results() []interface{} {
 // KeyValuePingFunc describes the behavior when the Ping method of the
 // parent MockKeyValue instance is invoked.
 type KeyValuePingFunc struct {
-	defaultHook func() error
-	hooks       []func() error
+	defaultHook func(context.Context) error
+	hooks       []func(context.Context) error
 	history     []KeyValuePingFuncCall
 	mutex       sync.Mutex
 }
 
 // Ping delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockKeyValue) Ping() error {
-	r0 := m.PingFunc.nextHook()()
-	m.PingFunc.appendCall(KeyValuePingFuncCall{r0})
+func (m *MockKeyValue) Ping(v0 context.Context) error {
+	r0 := m.PingFunc.nextHook()(v0)
+	m.PingFunc.appendCall(KeyValuePingFuncCall{v0, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the Ping method of the
 // parent MockKeyValue instance is invoked and the hook queue is empty.
-func (f *KeyValuePingFunc) SetDefaultHook(hook func() error) {
+func (f *KeyValuePingFunc) SetDefaultHook(hook func(context.Context) error) {
 	f.defaultHook = hook
 }
 
@@ -2379,7 +2391,7 @@ func (f *KeyValuePingFunc) SetDefaultHook(hook func() error) {
 // Ping method of the parent MockKeyValue instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *KeyValuePingFunc) PushHook(hook func() error) {
+func (f *KeyValuePingFunc) PushHook(hook func(context.Context) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2388,19 +2400,19 @@ func (f *KeyValuePingFunc) PushHook(hook func() error) {
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *KeyValuePingFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func() error {
+	f.SetDefaultHook(func(context.Context) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *KeyValuePingFunc) PushReturn(r0 error) {
-	f.PushHook(func() error {
+	f.PushHook(func(context.Context) error {
 		return r0
 	})
 }
 
-func (f *KeyValuePingFunc) nextHook() func() error {
+func (f *KeyValuePingFunc) nextHook() func(context.Context) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2433,6 +2445,9 @@ func (f *KeyValuePingFunc) History() []KeyValuePingFuncCall {
 // KeyValuePingFuncCall is an object that describes an invocation of method
 // Ping on an instance of MockKeyValue.
 type KeyValuePingFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -2441,7 +2456,7 @@ type KeyValuePingFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c KeyValuePingFuncCall) Args() []interface{} {
-	return []interface{}{}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/redispool/redispool_test.go
+++ b/internal/redispool/redispool_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/tenant"
 )
 
 func TestSchemeMatcher(t *testing.T) {
@@ -38,11 +40,12 @@ func TestMain(m *testing.M) {
 func TestDeleteAllKeysWithPrefix(t *testing.T) {
 	t.Helper()
 
+	ctx := tenant.TestContext()
 	kv := NewTestKeyValue()
 
 	// If we are not on CI, skip the test if our redis connection fails.
 	if os.Getenv("CI") == "" {
-		if err := kv.Ping(); err != nil {
+		if err := kv.Ping(ctx); err != nil {
 			t.Skip("could not connect to redis", err)
 		}
 	}

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -400,7 +400,7 @@ func (w *Worker[T]) handle(ctx, workerContext context.Context, record T) (err er
 	}
 	duration := time.Since(start)
 	if w.recorder != nil {
-		go w.recorder.LogRun(w, duration, handleErr)
+		go w.recorder.LogRun(ctx, w, duration, handleErr)
 	}
 
 	if errcode.IsNonRetryable(handleErr) || handleErr != nil && w.isJobCanceled(record.RecordUID(), handleErr, ctx.Err()) {

--- a/internal/wrexec/BUILD.bazel
+++ b/internal/wrexec/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     deps = [
         ":wrexec",
         "//internal/rcache",
+        "//internal/tenant",
         "//lib/errors",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_log//:log",

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -113,7 +113,7 @@ func (rc *RecordingCmd) WithRedactorFunc(f RedactorFunc) *RecordingCmd {
 	return rc
 }
 
-func (rc *RecordingCmd) after(_ context.Context, logger log.Logger, cmd *exec.Cmd) {
+func (rc *RecordingCmd) after(ctx context.Context, logger log.Logger, cmd *exec.Cmd) {
 	// ensure we don't record ourselves twice if the caller calls Wait() twice for example.
 	defer func() { rc.done = true }()
 	if rc.done {
@@ -163,7 +163,7 @@ func (rc *RecordingCmd) after(_ context.Context, logger log.Logger, cmd *exec.Cm
 		return
 	}
 
-	_ = rc.store.Insert(data)
+	_ = rc.store.Insert(ctx, data)
 }
 
 // RecordingCommandFactory stores a ShouldRecord that will be used to create a new RecordingCommand

--- a/internal/wrexec/recording_cmd_test.go
+++ b/internal/wrexec/recording_cmd_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/tenant"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func listSize(t *testing.T, store *rcache.FIFOList) int {
 	t.Helper()
-	size, err := store.Size()
+	size, err := store.Size(tenant.TestContext())
 	if err != nil {
 		t.Fatalf("failed to get size of FIFOList: %s", err)
 	}


### PR DESCRIPTION
This PR takes the first step towards checking the tenant ID in Redis, by starting to pass in `ctx` for some operations. To scope things, we just update the "list" operations for now.

Note: we're not enforcing or namespacing by tenant ID yet.

## Test plan

Adapted tests