### PR TITLE
database: limit concurrent event log inserts

### DIFF
--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -131,6 +131,7 @@ go_library(
         "//internal/jsonc",
         "//internal/lazyregexp",
         "//internal/licensing",
+        "//internal/limiter",
         "//internal/own/codeowners/v1:codeowners",
         "//internal/own/types",
         "//internal/perforce",

--- a/internal/limiter/limiter.go
+++ b/internal/limiter/limiter.go
@@ -1,5 +1,7 @@
 package limiter
 
+import "context"
+
 // Limiter is a fixed-sized unweighted semaphore.
 // The zero value is usable and applies no limiting.
 type Limiter chan struct{}
@@ -12,6 +14,20 @@ func (l Limiter) Acquire() {
 	if l != nil {
 		l <- struct{}{}
 	}
+}
+
+// AcquireContext respects ctx's deadline when trying to acquire the
+// semaphore.
+func (l Limiter) AcquireContext(ctx context.Context) error {
+	if l != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case l <- struct{}{}:
+			return nil
+		}
+	}
+	return nil
 }
 
 func (l Limiter) Release() {


### PR DESCRIPTION
We have had downtime on dotcom twice this week due to a fast migration that tries to acquire a lock on the event_logs table. In both cases we had a huge backlog of events to write to the DB which ended up exhausting the connection pool since they also don't respect context cancellation.

This is a speculative fix for this. The default of 5 was just made up, I didn't want to go too low and I know this still gives lots of space for other connections in our pool. I don't really want to test it on dotcom after it lands, just in case it doesn't work :)

Test Plan: CI to just check it still works.

Part of https://linear.app/sourcegraph/issue/SRC-547/defensive-patterns-for-how-we-use-db-connection-pools