### PR TITLE
refactor(svelte): Refactor pagination/infinity query API

### DIFF
--- a/client/web-sveltekit/src/lib/codenav/ExplorePanel.svelte
+++ b/client/web-sveltekit/src/lib/codenav/ExplorePanel.svelte
@@ -194,7 +194,7 @@
             afterCursor: null,
         }
 
-        return infinityQuery({
+        return createPagination({
             client,
             query: ExplorePanel_Usages,
             variables: baseVariables,
@@ -240,7 +240,7 @@
     import { getContext, setContext } from 'svelte'
     import { type Writable } from 'svelte/store'
 
-    import { infinityQuery, type GraphQLClient, type InfinityQueryStore } from '$lib/graphql'
+    import { type GraphQLClient, createPagination, type Pagination } from '$lib/graphql'
     import { SymbolUsageKind } from '$lib/graphql-types'
     import Icon from '$lib/Icon.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
@@ -260,7 +260,7 @@
     import ExplorePanelFileUsages from './ExplorePanelFileUsages.svelte'
 
     export let inputs: Writable<ExplorePanelInputs>
-    export let connection: InfinityQueryStore<ExplorePanel_Usage[], ExplorePanel_UsagesVariables> | undefined
+    export let connection: Pagination<ExplorePanel_Usage[], ExplorePanel_UsagesVariables> | undefined
     export let treeState: Writable<SingleSelectTreeState>
 
     $: setTreeContext(treeState)
@@ -279,7 +279,7 @@
         })
     }
 
-    $: loading = $connection?.fetching
+    $: loading = $connection?.loading
     $: usages = $connection?.data ?? []
     $: kindFilteredUsages = usages.filter(matchesUsageKind($inputs.usageKindFilter))
     $: pathGroups = groupUsages(kindFilteredUsages)

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -337,7 +337,7 @@
                         {#key data.filePath}
                             <HistoryPanel
                                 bind:this={historyPanel}
-                                history={data.commitHistory}
+                                historyPagination={data.historyPagination}
                                 enableInlineDiff={$page.data.enableInlineDiff}
                                 enableViewAtCommit={$page.data.enableViewAtCommit}
                             />

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -5,7 +5,7 @@ import { readable, derived, type Readable } from 'svelte/store'
 import { SourcegraphURL } from '@sourcegraph/common'
 
 import { CodyContextFiltersSchema, getFiltersFromCodyContextFilters } from '$lib/cody/config'
-import { getGraphQLClient, infinityQuery, type GraphQLClient, IncrementalRestoreStrategy } from '$lib/graphql'
+import { getGraphQLClient, type GraphQLClient, IncrementalRestoreStrategy, createPagination } from '$lib/graphql'
 import { ROOT_PATH, fetchSidebarFileTree } from '$lib/repo/api/tree'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
@@ -51,7 +51,7 @@ export const load: LayoutLoad = async ({ parent, params, url }) => {
             )
             .then(result => result.data?.repository?.lastCommit?.ancestors.nodes[0]),
         // Fetches the most recent commits for current blob, tree or repo root
-        commitHistory: infinityQuery({
+        historyPagination: createPagination({
             client,
             query: GitHistoryQuery,
             variables: resolvedRevision.then(revspec => ({

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/changelists/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/changelists/[...path]/+page.svelte
@@ -17,31 +17,31 @@
     // position, so both can be restored when the user refreshes the page or navigates
     // back to it.
     export const snapshot: Snapshot<{
-        changelists: ReturnType<typeof data.changelistsQuery.capture>
+        changelistsPagination: ReturnType<PageData['changelistsPagination']['capture']>
         scroller: ScrollerCapture
     }> = {
         capture() {
             return {
-                changelists: changelistsQuery.capture(),
+                changelistsPagination: changelistsPagination.capture(),
                 scroller: scroller.capture(),
             }
         },
         async restore(snapshot) {
             if (get(navigating)?.type === 'popstate') {
-                await changelistsQuery?.restore(snapshot.changelists)
+                await changelistsPagination?.restore(snapshot.changelistsPagination)
             }
             scroller.restore(snapshot.scroller)
         },
     }
 
     function fetchMore() {
-        changelistsQuery?.fetchMore()
+        changelistsPagination?.fetchMore()
     }
 
     let scroller: Scroller
 
-    $: changelistsQuery = data.changelistsQuery
-    $: changelists = $changelistsQuery.data
+    $: changelistsPagination = data.changelistsPagination
+    $: changelists = $changelistsPagination.data
     $: pageTitle = (() => {
         const parts = ['Changelists']
         if (data.path) {
@@ -103,14 +103,14 @@
                 {/each}
             </ul>
         {/if}
-        {#if $changelistsQuery.fetching}
+        {#if $changelistsPagination.loading}
             <div class="footer">
                 <LoadingSpinner />
             </div>
-        {:else if !$changelistsQuery.fetching && $changelistsQuery.error}
+        {:else if !$changelistsPagination.loading && $changelistsPagination.error}
             <div class="footer">
                 <Alert variant="danger">
-                    Unable to fetch changelists: {$changelistsQuery.error.message}
+                    Unable to fetch changelists: {$changelistsPagination.error.message}
                 </Alert>
             </div>
         {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/changelists/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/changelists/[...path]/+page.ts
@@ -1,6 +1,6 @@
 import { parseRepoRevision } from '@sourcegraph/shared/src/util/url'
 
-import { IncrementalRestoreStrategy, getGraphQLClient, infinityQuery } from '$lib/graphql'
+import { IncrementalRestoreStrategy, createPagination, getGraphQLClient } from '$lib/graphql'
 import { resolveRevision } from '$lib/repo/utils'
 
 import type { PageLoad } from './$types'
@@ -14,7 +14,7 @@ export const load: PageLoad = ({ parent, params }) => {
     const path = params.path ? decodeURIComponent(params.path) : ''
     const resolvedRevision = resolveRevision(parent, revision)
 
-    const changelistsQuery = infinityQuery({
+    const changelistsPagination = createPagination({
         client,
         query: ChangelistsPage_ChangelistsQuery,
         variables: resolvedRevision.then(revision => ({
@@ -45,7 +45,7 @@ export const load: PageLoad = ({ parent, params }) => {
     })
 
     return {
-        changelistsQuery,
+        changelistsPagination,
         path,
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
@@ -19,31 +19,31 @@
     // position, so both can be restored when the user refreshes the page or navigates
     // back to it.
     export const snapshot: Snapshot<{
-        commits: ReturnType<typeof data.commitsQuery.capture>
+        commits: ReturnType<PageData['commitsPagination']['capture']>
         scroller: ScrollerCapture
     }> = {
         capture() {
             return {
-                commits: commitsQuery.capture(),
+                commits: commitsPagination.capture(),
                 scroller: scroller.capture(),
             }
         },
         async restore(snapshot) {
             if (get(navigating)?.type === 'popstate') {
-                await commitsQuery?.restore(snapshot.commits)
+                await commitsPagination?.restore(snapshot.commits)
             }
             scroller.restore(snapshot.scroller)
         },
     }
 
     function fetchMore() {
-        commitsQuery?.fetchMore()
+        commitsPagination?.fetchMore()
     }
 
     let scroller: Scroller
 
-    $: commitsQuery = data.commitsQuery
-    $: commits = $commitsQuery.data
+    $: commitsPagination = data.commitsPagination
+    $: commits = $commitsPagination.data
     $: pageTitle = (() => {
         const parts = ['Commits']
         if (data.path) {
@@ -116,14 +116,14 @@
                 {/each}
             </ul>
         {/if}
-        {#if $commitsQuery.fetching}
+        {#if $commitsPagination.loading}
             <div class="footer">
                 <LoadingSpinner />
             </div>
-        {:else if !$commitsQuery.fetching && $commitsQuery.error}
+        {:else if !$commitsPagination.loading && $commitsPagination.error}
             <div class="footer">
                 <Alert variant="danger">
-                    Unable to fetch commits: {$commitsQuery.error.message}
+                    Unable to fetch commits: {$commitsPagination.error.message}
                 </Alert>
             </div>
         {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
@@ -1,4 +1,4 @@
-import { IncrementalRestoreStrategy, getGraphQLClient, infinityQuery } from '$lib/graphql'
+import { IncrementalRestoreStrategy, createPagination, getGraphQLClient } from '$lib/graphql'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
 
@@ -13,7 +13,7 @@ export const load: PageLoad = ({ parent, params }) => {
     const path = params.path ? decodeURIComponent(params.path) : ''
     const resolvedRevision = resolveRevision(parent, revision)
 
-    const commitsQuery = infinityQuery({
+    const commitsPagination = createPagination({
         client,
         query: CommitsPage_CommitsQuery,
         variables: resolvedRevision.then(revision => ({
@@ -44,7 +44,7 @@ export const load: PageLoad = ({ parent, params }) => {
     })
 
     return {
-        commitsQuery,
+        commitsPagination,
         path,
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.svelte
@@ -15,18 +15,18 @@
     export let data: PageData
 
     export const snapshot: Snapshot<{
-        branches: ReturnType<typeof data.branchesQuery.capture>
+        branchesPagination: ReturnType<PageData['branchesPagination']['capture']>
         scroller: ScrollerCapture
     }> = {
         capture() {
             return {
-                branches: data.branchesQuery.capture(),
+                branchesPagination: data.branchesPagination.capture(),
                 scroller: scroller.capture(),
             }
         },
         async restore(snapshot) {
             if (get(navigating)?.type === 'popstate') {
-                await data.branchesQuery?.restore(snapshot.branches)
+                await data.branchesPagination?.restore(snapshot.branchesPagination)
             }
             scroller.restore(snapshot.scroller)
         },
@@ -35,8 +35,8 @@
     let scroller: Scroller
 
     $: query = data.query
-    $: branchesQuery = data.branchesQuery
-    $: branches = $branchesQuery.data
+    $: branchesPagination = data.branchesPagination
+    $: branches = $branchesPagination.data
 </script>
 
 <svelte:head>
@@ -47,17 +47,17 @@
     <Input type="search" name="query" placeholder="Search branches" value={query} autofocus />
     <Button variant="primary" type="submit">Search</Button>
 </form>
-<Scroller bind:this={scroller} margin={600} on:more={branchesQuery.fetchMore}>
+<Scroller bind:this={scroller} margin={600} on:more={branchesPagination.fetchMore}>
     <div class="main">
         {#if branches && branches.nodes.length > 0}
             <GitReferencesTable references={branches.nodes} referenceType={GitRefType.GIT_BRANCH} />
         {/if}
         <div>
-            {#if $branchesQuery.fetching}
+            {#if $branchesPagination.loading}
                 <LoadingSpinner />
-            {:else if $branchesQuery.error}
+            {:else if $branchesPagination.error}
                 <Alert variant="danger">
-                    Unable to load branches: {$branchesQuery.error.message}
+                    Unable to load branches: {$branchesPagination.error.message}
                 </Alert>
             {:else if !branches || branches.nodes.length === 0}
                 <Alert variant="info">No branches found</Alert>
@@ -98,6 +98,7 @@
         color: var(--text-muted);
         // Unset `div` width: 100% to allow the footer to be centered
         width: initial;
+        align-self: center;
     }
 
     @media (--mobile) {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/branches/all/+page.ts
@@ -1,4 +1,4 @@
-import { getGraphQLClient, infinityQuery, OverwriteRestoreStrategy } from '$lib/graphql'
+import { createPagination, getGraphQLClient, OverwriteRestoreStrategy } from '$lib/graphql'
 import { parseRepoRevision } from '$lib/shared'
 
 import type { PageLoad } from './$types'
@@ -13,7 +13,7 @@ export const load: PageLoad = ({ params, url }) => {
 
     return {
         query,
-        branchesQuery: infinityQuery({
+        branchesPagination: createPagination({
             client,
             query: AllBranchesPage_BranchesQuery,
             variables: {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/changelist/[changelistID]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/changelist/[changelistID]/+page.svelte
@@ -18,7 +18,7 @@
 
     interface Capture {
         scroll: ScrollerCapture
-        diffs?: ReturnType<NonNullable<typeof data.diff>['capture']>
+        diffPagination?: ReturnType<NonNullable<PageData['diffPagination']>['capture']>
         expandedDiffs: Array<[number, boolean]>
     }
 
@@ -27,13 +27,13 @@
     export const snapshot: Snapshot<Capture> = {
         capture: () => ({
             scroll: scroller.capture(),
-            diffs: diffQuery?.capture(),
+            diffPagination: data.diffPagination?.capture(),
             expandedDiffs: expandedDiffsSnapshot,
         }),
         restore: async capture => {
             expandedDiffs = new Map(capture.expandedDiffs)
             if (get(navigating)?.type === 'popstate') {
-                await data.diff?.restore(capture.diffs)
+                await data.diffPagination?.restore(capture.diffPagination)
             }
             scroller.restore(capture.scroll)
         },
@@ -44,8 +44,8 @@
     let expandedDiffs = new Map<number, boolean>()
     let expandedDiffsSnapshot: Array<[number, boolean]> = []
 
-    $: diffQuery = data.diff
-    $: diffs = $diffQuery?.data
+    $: diffPagination = data.diffPagination
+    $: diffs = $diffPagination?.data
     $: cid = data.changelist.cid
 
     afterNavigate(() => {
@@ -65,7 +65,7 @@
 
 <section>
     {#if data.changelist}
-        <Scroller bind:this={scroller} margin={600} on:more={diffQuery?.fetchMore}>
+        <Scroller bind:this={scroller} margin={600} on:more={diffPagination?.fetchMore}>
             <div class="header">
                 <div class="info">
                     <Changelist changelist={data.changelist} alwaysExpanded={!$isViewportMobile} />
@@ -100,12 +100,12 @@
                     {/each}
                 </ul>
             {/if}
-            {#if $diffQuery?.fetching}
+            {#if $diffPagination?.loading}
                 <LoadingSpinner />
-            {:else if $diffQuery?.error}
+            {:else if $diffPagination?.error}
                 <div class="error">
                     <Alert variant="danger">
-                        Unable to fetch file diffs: {$diffQuery.error.message}
+                        Unable to fetch file diffs: {$diffPagination.error.message}
                     </Alert>
                 </div>
             {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/changelist/[changelistID]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/changelist/[changelistID]/+page.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit'
 
-import { IncrementalRestoreStrategy, getGraphQLClient, infinityQuery } from '$lib/graphql'
+import { IncrementalRestoreStrategy, createPagination, getGraphQLClient } from '$lib/graphql'
 
 import type { PageLoad } from './$types'
 import { ChangelistPage_ChangelistQuery, ChangelistPage_DiffQuery } from './page.gql'
@@ -28,9 +28,9 @@ export const load: PageLoad = async ({ params }) => {
     // parents is an empty array for the initial commit
     // We currently don't support diffs for the initial commit on the backend
 
-    const diff =
+    const diffPagination =
         changelist.cid && changelist?.commit.parents[0]?.parent?.cid
-            ? infinityQuery({
+            ? createPagination({
                   client,
                   query: ChangelistPage_DiffQuery,
                   variables: {
@@ -60,6 +60,6 @@ export const load: PageLoad = async ({ params }) => {
 
     return {
         changelist,
-        diff,
+        diffPagination,
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
@@ -22,7 +22,7 @@
 
     interface Capture {
         scroll: ScrollerCapture
-        diffs?: ReturnType<NonNullable<typeof data.diff>['capture']>
+        diffs?: ReturnType<NonNullable<PageData['diffPagination']>['capture']>
         expandedDiffs: Array<[number, boolean]>
     }
 
@@ -31,13 +31,13 @@
     export const snapshot: Snapshot<Capture> = {
         capture: () => ({
             scroll: scroller.capture(),
-            diffs: diffQuery?.capture(),
+            diffs: diffPagination?.capture(),
             expandedDiffs: expandedDiffsSnapshot,
         }),
         restore: async capture => {
             expandedDiffs = new Map(capture.expandedDiffs)
             if (get(navigating)?.type === 'popstate') {
-                await data.diff?.restore(capture.diffs)
+                await data.diffPagination?.restore(capture.diffs)
             }
             scroller.restore(capture.scroll)
         },
@@ -48,8 +48,8 @@
     let expandedDiffs = new Map<number, boolean>()
     let expandedDiffsSnapshot: Array<[number, boolean]> = []
 
-    $: diffQuery = data.diff
-    $: diffs = $diffQuery?.data
+    $: diffPagination = data.diffPagination
+    $: diffs = $diffPagination?.data
 
     afterNavigate(() => {
         repositoryContext.set({ revision: data.commit.abbreviatedOID })
@@ -68,7 +68,7 @@
 
 <section>
     {#if data.commit}
-        <Scroller bind:this={scroller} margin={600} on:more={diffQuery?.fetchMore}>
+        <Scroller bind:this={scroller} margin={600} on:more={diffPagination?.fetchMore}>
             <div class="header">
                 <div class="info"><Commit commit={data.commit} alwaysExpanded={!$isViewportMobile} /></div>
                 <ul class="actions">
@@ -123,12 +123,12 @@
                     {/each}
                 </ul>
             {/if}
-            {#if $diffQuery?.fetching}
+            {#if $diffPagination?.loading}
                 <LoadingSpinner />
-            {:else if $diffQuery?.error}
+            {:else if $diffPagination?.error}
                 <div class="error">
                     <Alert variant="danger">
-                        Unable to fetch file diffs: {$diffQuery.error.message}
+                        Unable to fetch file diffs: {$diffPagination.error.message}
                     </Alert>
                 </div>
             {/if}

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.ts
@@ -1,6 +1,6 @@
 import { error, redirect } from '@sveltejs/kit'
 
-import { IncrementalRestoreStrategy, getGraphQLClient, infinityQuery } from '$lib/graphql'
+import { IncrementalRestoreStrategy, createPagination, getGraphQLClient } from '$lib/graphql'
 import { parseRepoRevision } from '$lib/shared'
 
 import type { PageLoad } from './$types'
@@ -31,9 +31,9 @@ export const load: PageLoad = async ({ url, params }) => {
 
     // parents is an empty array for the initial commit
     // We currently don't support diffs for the initial commit on the backend
-    const diff =
+    const diffPagination =
         commit?.oid && commit?.parents[0]?.oid
-            ? infinityQuery({
+            ? createPagination({
                   client,
                   query: CommitPage_DiffQuery,
                   variables: {
@@ -63,6 +63,6 @@ export const load: PageLoad = async ({ url, params }) => {
 
     return {
         commit,
-        diff,
+        diffPagination,
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/tags/+page.svelte
@@ -14,16 +14,16 @@
 
     export let data: PageData
 
-    export const snapshot: Snapshot<{ tags: ReturnType<typeof data.tagsQuery.capture>; scroller: ScrollerCapture }> = {
+    export const snapshot: Snapshot<{ tags: ReturnType<typeof data.tagsPagination.capture>; scroller: ScrollerCapture }> = {
         capture() {
             return {
-                tags: data.tagsQuery.capture(),
+                tags: data.tagsPagination.capture(),
                 scroller: scroller.capture(),
             }
         },
         async restore(snapshot) {
             if (snapshot?.tags && get(navigating)?.type === 'popstate') {
-                await data.tagsQuery?.restore(snapshot.tags)
+                await data.tagsPagination?.restore(snapshot.tags)
             }
             scroller.restore(snapshot.scroller)
         },
@@ -32,8 +32,8 @@
     let scroller: Scroller
 
     $: query = data.query
-    $: tagsQuery = data.tagsQuery
-    $: tags = $tagsQuery.data
+    $: tagsPagination = data.tagsPagination
+    $: tags = $tagsPagination.data
 </script>
 
 <svelte:head>
@@ -45,17 +45,17 @@
         <Input type="search" name="query" placeholder="Search tags" value={query} autofocus />
         <Button variant="primary" type="submit">Search</Button>
     </form>
-    <Scroller bind:this={scroller} margin={600} on:more={tagsQuery.fetchMore}>
+    <Scroller bind:this={scroller} margin={600} on:more={tagsPagination.fetchMore}>
         <div class="main">
             {#if tags && tags.nodes.length > 0}
                 <GitReferencesTable references={tags.nodes} referenceType={GitRefType.GIT_TAG} />
             {/if}
             <div>
-                {#if $tagsQuery.fetching}
+                {#if $tagsPagination.loading}
                     <LoadingSpinner />
-                {:else if $tagsQuery.error}
+                {:else if $tagsPagination.error}
                     <Alert variant="danger">
-                        Unable to load tags: {$tagsQuery.error.message}
+                        Unable to load tags: {$tagsPagination.error.message}
                     </Alert>
                 {:else if !tags || tags.nodes.length === 0}
                     <Alert variant="info">No tags found</Alert>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/tags/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/tags/+page.ts
@@ -1,4 +1,4 @@
-import { OverwriteRestoreStrategy, getGraphQLClient, infinityQuery } from '$lib/graphql'
+import { OverwriteRestoreStrategy, createPagination, getGraphQLClient } from '$lib/graphql'
 import { parseRepoRevision } from '$lib/shared'
 
 import type { PageLoad } from './$types'
@@ -13,7 +13,7 @@ export const load: PageLoad = ({ params, url }) => {
 
     return {
         query,
-        tagsQuery: infinityQuery({
+        tagsPagination: createPagination({
             client,
             query: TagsPage_TagsQuery,
             variables: {


### PR DESCRIPTION
I'm refactoring the `infinityQuery` API in preparation for another PR. Naming changes aside, the main change is that the API now allows to navigate backwards too, so that we can use the same API for bidirectional in-memory pagination.

My goal is to have a single interface for creating "paginated queries" (in a broad sense). Eventually it should allow to optionally sync the state to and from the URL, but I didn't get that far (and the in-memory version is what I want for now).

As an example I converted the commits list on the contributors page to use the new API instead of relying on the page loader?

**Why do we need this at all?**

Doing true paginated queries via the page loader is convenient but not always applicable. E.g when we have multiple data sources, like the contributors page, then going to the next list of commits will retrigger the page loader, and thus the diffs query.
In this specific example that's not an issue because the data is cached, but in other situations we may not have cached data and do not want to trigger the whole page loader.
That's the problem that the in-memory pagination solves.

Aside from that I think having a single way to paginated or repeated queries is nice.

## Test plan

- Can navigate back and forth in commits on the compare page
- Infinity scrolling and restoring works on commits, tags, and branches pages.