### PR TITLE
codeintel: run uploads ExpireFailedRecords janitor job every 30m

### DIFF
--- a/internal/codeintel/uploads/internal/background/janitor/config.go
+++ b/internal/codeintel/uploads/internal/background/janitor/config.go
@@ -30,7 +30,7 @@ func (c *Config) Load() {
 	commitResolverMaximumCommitLagName := env.ChooseFallbackVariableName("CODEINTEL_UPLOADS_COMMIT_RESOLVER_MAXIMUM_COMMIT_LAG", "PRECISE_CODE_INTEL_COMMIT_RESOLVER_MAXIMUM_COMMIT_LAG")
 	uploadTimeoutName := env.ChooseFallbackVariableName("CODEINTEL_UPLOADS_UPLOAD_TIMEOUT", "PRECISE_CODE_INTEL_UPLOAD_TIMEOUT")
 
-	c.Interval = c.GetInterval("CODEINTEL_UPLOADS_CLEANUP_INTERVAL", "1m", "How frequently to run the updater janitor routine.")
+	c.Interval = c.GetInterval("CODEINTEL_UPLOADS_CLEANUP_INTERVAL", "30m", "How frequently to run the updater janitor routine.")
 	c.AbandonedSchemaVersionsInterval = c.GetInterval("CODEINTEL_UPLOADS_ABANDONED_SCHEMA_VERSIONS_CLEANUP_INTERVAL", "24h", "How frequently to run the query to clean up *_schema_version records that are not tracked by foreign key.")
 	c.MinimumTimeSinceLastCheck = c.GetInterval(minimumTimeSinceLastCheckName, "24h", "The minimum time the commit resolver will re-check an upload or index record.")
 	c.CommitResolverBatchSize = c.GetInt(commitResolverBatchSizeName, "100", "The maximum number of unique commits to resolve at a time.")


### PR DESCRIPTION
I was inspecting the dotcom frontend database slow query log, and this query by far was using the most clock time over the period. We should look into making this run faster, but for now we can just not run it as often. It's a janitor job, so not critical to run as often.

Test Plan: change is so simple that I will just see if this disappears from the slow query log.

Data here https://linear.app/sourcegraph/issue/SRC-548/enumerate-long-running-transactionsqueries-on-dotcom-and-s2#comment-c0e1c184