### PR TITLE
fix(svelte): Workaround for handling client-side redirections in production

### DIFF
--- a/client/web-sveltekit/src/routes/+error.svelte
+++ b/client/web-sveltekit/src/routes/+error.svelte
@@ -1,22 +1,36 @@
 <script lang="ts">
+    import { goto } from '$app/navigation'
     import { page } from '$app/stores'
     import HeroPage from '$lib/HeroPage.svelte'
     import { isCloneInProgressErrorLike, isRepoNotFoundErrorLike, isRevisionNotFoundErrorLike } from '$lib/shared'
 
+    import { SgRedirect } from '../hooks.client'
+
     import CloneInProgressError from './[...repo=reporev]/CloneInProgressError.svelte'
     import RepoNotFoundError from './[...repo=reporev]/RepoNotFoundError.svelte'
     import RevisionNotFoundError from './[...repo=reporev]/RevisionNotFoundError.svelte'
+
+    let showError = true
+
+    // This is a nasty workaround to handle a production bug where redirects are not recognized by SvelteKit.
+    // See the comment in hooks.client.ts ans SRCH-926 for more information
+    $: if ($page.error instanceof SgRedirect) {
+        showError = false
+        goto($page.error.redirect.location)
+    }
 </script>
 
-{#if isRepoNotFoundErrorLike($page.error)}
-    <RepoNotFoundError repoName={$page.params.repo} viewerCanAdminister={$page.data.user?.siteAdmin ?? false} />
-{:else if isCloneInProgressErrorLike($page.error)}
-    <CloneInProgressError repoName={$page.params.repo} error={$page.error} />
-{:else if isRevisionNotFoundErrorLike($page.error)}
-    <RevisionNotFoundError />
-{:else}
-    <HeroPage title="Unexpected Error" icon={ILucideCircleX}>
-        <!-- TODO: format error message with markdown -->
-        {$page.error?.message ?? '(no error message)'}
-    </HeroPage>
+{#if showError}
+    {#if isRepoNotFoundErrorLike($page.error)}
+        <RepoNotFoundError repoName={$page.params.repo} viewerCanAdminister={$page.data.user?.siteAdmin ?? false} />
+    {:else if isCloneInProgressErrorLike($page.error)}
+        <CloneInProgressError repoName={$page.params.repo} error={$page.error} />
+    {:else if isRevisionNotFoundErrorLike($page.error)}
+        <RevisionNotFoundError />
+    {:else}
+        <HeroPage title="Unexpected Error" icon={ILucideCircleX}>
+            <!-- TODO: format error message with markdown -->
+            {$page.error?.message ?? '(no error message)'}
+        </HeroPage>
+    {/if}
 {/if}


### PR DESCRIPTION
Fixes srch-927

This should fix the issue of seeing

    Unexpected Error
    [object Object]

when navigating to `/cody/chat` on dotcom and not being signed in.

This should not affect 'not found' errors that a triggered by SvelteKit itself.

This will also fix the `captureException` issues in Sentry, which are created when `handleErrorWithSentry` encounters thrown `Redirect`s.

## Test plan

Created a production Bazel build of the web app and ran it from a local instance. I added unconditional `redirect` and `error` calls to the `/cody/chat` page. Both have been handled as expected.
