### PR TITLE
lib/background: fix flaky test of monitor routines with context cancel

### DIFF
--- a/lib/background/background_test.go
+++ b/lib/background/background_test.go
@@ -63,6 +63,7 @@ func TestMonitorBackgroundRoutinesContextCancel(t *testing.T) {
 	}()
 
 	cancel()
+	time.Sleep(10 * time.Millisecond) // Give the goroutine a chance finish starting and exit.
 	<-unblocked
 
 	for _, r := range []*MockRoutine{r1, r2, r3} {


### PR DESCRIPTION
Address the data race problem brought up in https://github.com/sourcegraph/sourcegraph/pull/64252 with a different approach by giving a little delay in tests.

## Test plan

Before

```
❯ go test -count 1000 -run ^TestMonitorBackgroundRoutinesContextCancel$
...
--- FAIL: TestMonitorBackgroundRoutinesContextCancel (0.10s)
    background_test.go:74: unexpected number of calls to stop. want=1 have=0
    background_test.go:74: unexpected number of calls to stop. want=1 have=0
    background_test.go:74: unexpected number of calls to stop. want=1 have=0
```

After

```
❯ go test -count 1000 -run ^TestMonitorBackgroundRoutinesContextCancel$
PASS
ok  	github.com/sourcegraph/sourcegraph/lib/background	11.307s
```

