### PR TITLE
fix(svelte): Fix production build with Bazel

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -160,6 +160,9 @@ compile_app(
         },
     },
     visibility = ["//client/web/dist:__pkg__"],
+    # Without disabling the sandbox we get duplicate module imports which breaks certain SvelteKit behavior.
+    # See SRCH-926 for details.
+    tags = ["no-sandbox"],
 )
 
 playwright_test_bin.playwright_test(

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -152,6 +152,9 @@ compile_app(
         "BAZEL": "1",
     },
     out_dirs = ["build"],
+    # Without disabling the sandbox we get duplicate module imports which breaks certain SvelteKit behavior.
+    # See SRCH-926 for details.
+    tags = ["no-sandbox"],
     test_overrides = {
         "out_dirs": ["test_build"],
         "name": "web-sveltekit-test",
@@ -160,9 +163,6 @@ compile_app(
         },
     },
     visibility = ["//client/web/dist:__pkg__"],
-    # Without disabling the sandbox we get duplicate module imports which breaks certain SvelteKit behavior.
-    # See SRCH-926 for details.
-    tags = ["no-sandbox"],
 )
 
 playwright_test_bin.playwright_test(

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -142,7 +142,9 @@ npm_link_all_packages(name = "node_modules")
 
 compile_app(
     name = "web-sveltekit",
-    srcs = SRCS + BUILD_DEPS + CONFIGS,
+    srcs = SRCS + BUILD_DEPS + CONFIGS + [
+        ":sveltekit-sync"
+    ],
     args = [
         "build",
         "-c vite.config.ts",

--- a/client/web-sveltekit/src/hooks.client.ts
+++ b/client/web-sveltekit/src/hooks.client.ts
@@ -1,8 +1,6 @@
 import { handleErrorWithSentry } from '@sentry/sveltekit'
 import * as Sentry from '@sentry/sveltekit'
 
-import { asError } from '$lib/common'
-
 Sentry.init({
     // Disabled if dsn is undefined
     dsn: window.context.sentryDSN ?? undefined,
@@ -27,18 +25,4 @@ Sentry.init({
     tracesSampleRate: 1.0,
 })
 
-export const handleError = handleErrorWithSentry(({ error }: { error: unknown }) => {
-    // When throwing _expected errors_ in data loaders via SvelteKit's `error`function,
-    // the error is wrapped in an object with `status` and `body` properties (an instance
-    // of `HTTPError`).
-    // Usually SvelteKit will unwrap the error itself and actually not call this function.
-    // But this doesn't work in production builds with bazel due to the fact that the `HTTPError`
-    // class is defined multiple times, which makes the `instanceof` check fail (it's not
-    // clear why the class is defined multiple times).
-    // By unwrapping and returning the error here we can still render the proper error message
-    // in the UI, otherwise it would show a generic "Internal Error" message.
-    if (error && typeof error === 'object' && 'body' in error) {
-        return error.body as Error
-    }
-    return asError(error)
-})
+export const handleError = handleErrorWithSentry()


### PR DESCRIPTION
Alternative to #64520 

SvelteKit's error and redirect handling doesn't work as expected because the Bazel production build contains copies of specific classes, which breaks the `instanceof` checks that SvelteKit uses.

Disabling the sandbox solves that problem. See SRCH-926 for more details.

Fixes srch-926, srch-927

## Test plan

Created a production bazel build and served it from a local instance. Navigated to a non-existing repository and got the expected error page.
