### PR TITLE
telemetry: always best-effort write to v1 store

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/user.go
+++ b/cmd/frontend/internal/auth/openidconnect/user.go
@@ -85,7 +85,7 @@ func getOrCreateUser(
 		Data:     extsvc.NewUnencryptedData(serializedUser),
 	}
 
-	recorder := telemetryrecorder.New(db)
+	recorder := telemetryrecorder.New(logger, db)
 	newUserCreated, userID, safeErrMsg, err := auth.GetAndSaveUser(ctx, logger, db, recorder, auth.GetAndSaveUserOp{
 		UserProps: database.NewUser{
 			Username:        login,

--- a/cmd/frontend/internal/telemetry/resolvers/resolvers.go
+++ b/cmd/frontend/internal/telemetry/resolvers/resolvers.go
@@ -31,7 +31,7 @@ func New(logger log.Logger, db database.DB) graphqlbackend.TelemetryResolver {
 	return &Resolver{
 		logger:         logger,
 		db:             db,
-		telemetryStore: telemetrystore.New(db.TelemetryEventsExportQueue(), db.EventLogs()),
+		telemetryStore: telemetrystore.New(logger, db.TelemetryEventsExportQueue(), db.EventLogs()),
 	}
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -48,7 +48,7 @@ func TestRecorderEndToEnd(t *testing.T) {
 	exportStore.(database.MockExportModeSetterTelemetryEventsExportQueueStore).
 		SetMockExportMode(licensing.TelemetryEventsExportAll)
 
-	recorder := telemetry.NewEventRecorder(telemetrystore.New(exportStore, db.EventLogs()))
+	recorder := telemetry.NewEventRecorder(telemetrystore.New(logger, exportStore, db.EventLogs()))
 
 	wantEvents := 3
 	t.Run("Record and BatchRecord", func(t *testing.T) {

--- a/internal/telemetry/telemetrystore/BUILD.bazel
+++ b/internal/telemetry/telemetrystore/BUILD.bazel
@@ -9,5 +9,6 @@ go_library(
         "//internal/database",
         "//internal/telemetry",
         "//internal/telemetry/telemetrystore/teestore",
+        "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/internal/telemetry/telemetrystore/store.go
+++ b/internal/telemetry/telemetrystore/store.go
@@ -1,6 +1,7 @@
 package telemetrystore
 
 import (
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetrystore/teestore"
@@ -11,6 +12,6 @@ import (
 //
 // The current default tees events to both the legacy event_logs table, as well
 // as the new Telemetry Gateway export queue.
-func New(exportQueue database.TelemetryEventsExportQueueStore, eventLogs database.EventLogStore) telemetry.EventsStore {
-	return teestore.NewStore(exportQueue, eventLogs)
+func New(logger log.Logger, exportQueue database.TelemetryEventsExportQueueStore, eventLogs database.EventLogStore) telemetry.EventsStore {
+	return teestore.NewStore(logger, exportQueue, eventLogs)
 }

--- a/internal/telemetry/telemetrystore/teestore/BUILD.bazel
+++ b/internal/telemetry/telemetrystore/teestore/BUILD.bazel
@@ -15,12 +15,13 @@ go_library(
         "//internal/featureflag",
         "//internal/telemetry",
         "//internal/telemetry/sensitivemetadataallowlist",
+        "//internal/trace",
         "//lib/errors",
         "//lib/pointers",
         "//lib/telemetrygateway/v1:telemetrygateway",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
-        "@com_github_sourcegraph_conc//pool",
+        "@com_github_sourcegraph_log//:log",
     ],
 )
 

--- a/internal/updatecheck/client.go
+++ b/internal/updatecheck/client.go
@@ -402,9 +402,9 @@ func getAndMarshalRepoMetadataUsageJSON(ctx context.Context, db database.DB) (_ 
 	return json.Marshal(repoMetadataUsage)
 }
 
-func getLLMUsageData(ctx context.Context, db database.DB) (_ json.RawMessage, err error) {
+func getLLMUsageData(ctx context.Context, logger log.Logger, db database.DB) (_ json.RawMessage, err error) {
 	Manager := tokenusage.NewManager()
-	err = storeTokenUsageinDbBeforeRedisSync(ctx, db)
+	err = storeTokenUsageinDbBeforeRedisSync(ctx, logger, db)
 	if err != nil {
 		return nil, err
 	}
@@ -416,8 +416,8 @@ func getLLMUsageData(ctx context.Context, db database.DB) (_ json.RawMessage, er
 }
 
 // Stores in postgres right before the reset of the tokens to zero
-func storeTokenUsageinDbBeforeRedisSync(ctx context.Context, db database.DB) error {
-	recorder := telemetryrecorder.New(db)
+func storeTokenUsageinDbBeforeRedisSync(ctx context.Context, logger log.Logger, db database.DB) error {
+	recorder := telemetryrecorder.New(logger, db)
 	tokenManager := tokenusage.NewManager()
 	tokenUsageData, err := tokenManager.FetchTokenUsageDataForAnalysis()
 	if err != nil {
@@ -708,7 +708,7 @@ func updateBody(ctx context.Context, logger log.Logger, db database.DB) (io.Read
 	if err != nil {
 		logFunc("repoMetadataUsage failed", log.Error(err))
 	}
-	r.LlmUsage, err = getLLMUsageData(ctx, db)
+	r.LlmUsage, err = getLLMUsageData(ctx, scopedLog, db)
 	if err != nil {
 		logFunc("getLLMUsageData failed", log.Error(err))
 	}


### PR DESCRIPTION
In another PR addressing event_log tables being an issue, it was mentioned that we can just write to the legacy store without monitoring if it works or not. This commit implements that. Most of the code change is just prop drilling for the logger. We could simplify even further and not even log, but it feels like not being able to see the error anywhere would be hard to debug.

Test Plan: CI

Context: https://github.com/sourcegraph/sourcegraph/pull/64481#issuecomment-2291526398