### PR TITLE
fix(search): fix query parsing bug around quoted phrases

### DIFF
--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -10,6 +10,8 @@ const (
 	Literal labels = 1 << iota
 	Regexp
 	Quoted
+	// SingleQuoted will be set (in addition to Quoted) when the pattern was wrapped in single quotes '...'
+	SingleQuoted
 	HeuristicParensAsPatterns
 	HeuristicDanglingParens
 	HeuristicHoisted

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -14,7 +14,7 @@ func stringHumanPattern(nodes []Node) string {
 		case Pattern:
 			v := n.Value
 			if n.Annotation.Labels.IsSet(Quoted) {
-				v = strconv.Quote(v)
+				v = quoteValue(v, n.Annotation.Labels.IsSet(SingleQuoted))
 			}
 			if n.Annotation.Labels.IsSet(Regexp) {
 				v = Delimit(v, '/')
@@ -56,7 +56,7 @@ func stringHumanParameters(parameters []Parameter) string {
 	for _, p := range parameters {
 		v := p.Value
 		if p.Annotation.Labels.IsSet(Quoted) {
-			v = strconv.Quote(v)
+			v = quoteValue(v, p.Annotation.Labels.IsSet(SingleQuoted))
 		}
 		field := p.Field
 		if p.Annotation.Labels.IsSet(IsAlias) {
@@ -82,6 +82,14 @@ func stringHumanParameters(parameters []Parameter) string {
 		}
 	}
 	return strings.Join(result, " ")
+}
+
+func quoteValue(v string, single bool) string {
+	if single {
+		return fmt.Sprintf("'%s'", v)
+	} else {
+		return strconv.Quote(v)
+	}
 }
 
 // StringHuman creates a valid query string from a parsed query. It is used in

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -24,33 +24,39 @@ func TestExperimentalPhraseBoost(t *testing.T) {
 
 	// expect phrase query
 	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("foo bar bas", SearchTypeKeyword))
-	autogold.Expect(`(or "(foo and bar) and bas" (and "foo" "bar" "bas"))`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
 	autogold.Expect(`(or "* int func(" (and "*" "int" "func("))`).Equal(t, test("* int func(", SearchTypeKeyword))
 	autogold.Expect(`(or "\"foo bar\" bas qux" (and "foo bar" "bas" "qux"))`).Equal(t, test(`"foo bar" bas qux`, SearchTypeKeyword))
 	autogold.Expect(`(or "foo 'bar bas' qux" (and "foo" "bar bas" "qux"))`).Equal(t, test(`foo 'bar bas' qux`, SearchTypeKeyword))
 	autogold.Expect(`(and "type:file" (or "foo 'bar bas' qux" (and "foo" "bar bas" "qux")))`).Equal(t, test(`type:file foo 'bar bas' qux`, SearchTypeKeyword))
+	autogold.Expect(`(and "-lang:go" (or "foo 'bar bas' qux" (and "foo" "bar bas" "qux")))`).Equal(t, test(`-lang:go foo 'bar bas' qux`, SearchTypeKeyword))
 
 	// expect no phrase query
 	autogold.Expect(`"foo bar bas"`).Equal(t, test("/foo bar bas/", SearchTypeKeyword))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar" "ba.*")`).Equal(t, test("foo bar /ba.*/", SearchTypeKeyword))
 	autogold.Expect(`"foo"`).Equal(t, test("foo", SearchTypeKeyword))
-	autogold.Expect(`(or "foo and bar" (and "foo" "bar"))`).Equal(t, test("foo and bar", SearchTypeKeyword))
+	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo and bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" (not "bar"))`).Equal(t, test("foo not bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar" (not "bas") "quz")`).Equal(t, test("foo bar not bas quz", SearchTypeKeyword))
 	autogold.Expect(`(or "foo" "bar" "bas")`).Equal(t, test("foo or bar or bas", SearchTypeKeyword))
 	autogold.Expect(`(or (and "foo" "bar") (and "quz" "biz"))`).Equal(t, test("foo and bar or (quz and biz)", SearchTypeKeyword))
 	autogold.Expect(`(and "type:repo" "sourcegraph")`).Equal(t, test("type:repo 'sourcegraph'", SearchTypeKeyword))
 	autogold.Expect(`(and "type:diff" "//" "varargs")`).Equal(t, test("type:diff // varargs", SearchTypeKeyword))
+	autogold.Expect(`(and "repo:sourcegraph/cody@main" "the" "models" "other")`).Equal(t, test("repo:sourcegraph/cody@main the models and other ", SearchTypeKeyword))
 
 	// cases that came up in user feedback
 	autogold.Expect(`(and "repo:golang/go" (or "// The vararg opts parameter can include functions to configure the" (and "//" "The" "vararg" "opts" "parameter" "can" "include" "functions" "to" "configure" "the")))`).Equal(t, test("repo:golang/go // The vararg opts parameter can include functions to configure the", SearchTypeKeyword))
 	autogold.Expect(`(and "context:global" (or "invalid modelID;" (and "invalid" "modelID;")))`).Equal(t, test("context:global invalid modelID;", SearchTypeKeyword))
 	autogold.Expect(`(and "context:global" (or "return \"various\";" (and "return" "\"various\";")))`).Equal(t, test("context:global return \"various\";", SearchTypeKeyword))
 	autogold.Expect(`(and "repo:golang/go" (or "test server" (and "test" "server")))`).Equal(t, test("repo:golang/go test server", SearchTypeKeyword))
-	autogold.Expect(`(and "repo:sourcegraph/cody@main" (or "the models and other" (and "the" "models" "other")))`).Equal(t, test("repo:sourcegraph/cody@main the models and other ", SearchTypeKeyword))
 	autogold.Expect(`(and "repo:sourcegraph/cody@main" (or "'sourcegraph'" "sourcegraph"))`).Equal(t, test("repo:sourcegraph/cody@main 'sourcegraph'", SearchTypeKeyword))
 	autogold.Expect(`(and "repo:sourcegraph/zoekt" (or "\"some string\"" "some string"))`).Equal(t, test("repo:sourcegraph/zoekt \"some string\"", SearchTypeKeyword))
 
+	// cases to guard against regressions
+	autogold.Expect(`(or "\"disable_circuit_breaker: true\"" "disable_circuit_breaker: true")`).Equal(t, test(`"disable_circuit_breaker: true"`, SearchTypeKeyword))
+	autogold.Expect(`(or "\"repo:sourcegraph\"" "repo:sourcegraph")`).Equal(t, test(`"repo:sourcegraph"`, SearchTypeKeyword))
+	autogold.Expect(`(or "\"index: no\"" "index: no")`).Equal(t, test(`"index: no"`, SearchTypeKeyword))
+	autogold.Expect(`(and "index:no" (or "\" index:no \"" " index:no "))`).Equal(t, test(`index:no " index:no "`, SearchTypeKeyword))
 }
 
 func TestSubstituteAliases(t *testing.T) {


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/64298 we expanded "phrase boosting" to incorporate quoted terms. Unfortunately, the PR caused a regression in query parsing. It could accidentally rewrite queries like `"disable: true"` to just `" true"` because `disable:` looks a bit like a parameter.

This PR goes back to the original approach of using the parsed query nodes instead of manipulating the original query string (which is really tricky to get right). In order to preserve nice behavior for quoted strings, we introduce a way to determine whether a node was single quoted or double-quoted. That way, we can still rank single-quoted strings highly, for example `'lower'`.

## Test plan

More unit tests, extensive manual testing.

Note: we're doing a retrospective to debug why this slipped through. So I expect some follow-up refactors and test improvements too.

## Changelog

Fix a regression in query parsing that affected some quoted phrases, for example `"disable: true"`.