### PR TITLE
Only store commits in commitmap

### DIFF
--- a/internal/codeintel/autoindexing/internal/background/scheduler/iface.go
+++ b/internal/codeintel/autoindexing/internal/background/scheduler/iface.go
@@ -12,7 +12,7 @@ import (
 )
 
 type PolicyMatcher interface {
-	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, repoName api.RepoName, policies []policiesshared.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[string][]policies.PolicyMatch, error)
+	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, repoName api.RepoName, policies []policiesshared.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[api.CommitID][]policies.PolicyMatch, error)
 }
 
 type PoliciesService interface {

--- a/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
+++ b/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
@@ -190,7 +190,7 @@ func (b indexSchedulerJob) handleRepository(ctx context.Context, repositoryID, p
 			}
 
 			// Attempt to queue an index if one does not exist for each of the matching commits
-			if _, err := b.indexEnqueuer.QueueAutoIndexJobs(ctx, repositoryID, commit, "", false, false); err != nil {
+			if _, err := b.indexEnqueuer.QueueAutoIndexJobs(ctx, repositoryID, string(commit), "", false, false); err != nil {
 				if errors.HasType[*gitdomain.RevisionNotFoundError](err) {
 					continue
 				}

--- a/internal/codeintel/policies/helpers_test.go
+++ b/internal/codeintel/policies/helpers_test.go
@@ -1,8 +1,12 @@
 package policies
 
-import "sort"
+import (
+	"sort"
 
-func sortPolicyMatchesMap(policyMatches map[string][]PolicyMatch) {
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func sortPolicyMatchesMap(policyMatches map[api.CommitID][]PolicyMatch) {
 	for _, policyMatches := range policyMatches {
 		sortPolicyMatches(policyMatches)
 	}

--- a/internal/codeintel/policies/matcher.go
+++ b/internal/codeintel/policies/matcher.go
@@ -310,8 +310,10 @@ func (m *Matcher) matchCommitPolicies(ctx context.Context, context matcherContex
 				continue
 			}
 
-			context.commitMap[policy.Pattern] = append(context.commitMap[policy.Pattern], PolicyMatch{
-				Name:           string(commit.ID),
+			commitID := string(commit.ID)
+
+			context.commitMap[commitID] = append(context.commitMap[commitID], PolicyMatch{
+				Name:           policy.Pattern,
 				PolicyID:       &policy.ID,
 				PolicyDuration: policyDuration,
 				CommittedAt:    commit.Committer.Date,

--- a/internal/codeintel/policies/matcher_common_test.go
+++ b/internal/codeintel/policies/matcher_common_test.go
@@ -151,7 +151,7 @@ func testUploadExpirerMockGitserverClient(defaultBranchName string, now time.Tim
 	return gitserverClient
 }
 
-func hydrateCommittedAt(expectedPolicyMatches map[string][]PolicyMatch, now time.Time) {
+func hydrateCommittedAt(expectedPolicyMatches map[api.CommitID][]PolicyMatch, now time.Time) {
 	for commit, matches := range expectedPolicyMatches {
 		for i, match := range matches {
 			committedAt := testCommitDateFor(commit, now)
@@ -161,7 +161,7 @@ func hydrateCommittedAt(expectedPolicyMatches map[string][]PolicyMatch, now time
 	}
 }
 
-func testCommitDateFor(commit string, now time.Time) time.Time {
+func testCommitDateFor(commit api.CommitID, now time.Time) time.Time {
 	switch commit {
 	case "deadbeef00":
 		return now.Add(-time.Hour * 2)

--- a/internal/codeintel/policies/matcher_indexing_test.go
+++ b/internal/codeintel/policies/matcher_indexing_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	policiesshared "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -17,7 +18,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 	mainGitserverClient := testUploadExpirerMockGitserverClient("main", now)
 	developGitserverClient := testUploadExpirerMockGitserverClient("develop", now)
 
-	runTest := func(t *testing.T, gitserverClient gitserver.Client, policies []policiesshared.ConfigurationPolicy, expectedPolicyMatches map[string][]PolicyMatch) {
+	runTest := func(t *testing.T, gitserverClient gitserver.Client, policies []policiesshared.ConfigurationPolicy, expectedPolicyMatches map[api.CommitID][]PolicyMatch) {
 		t.Helper()
 		policyMatches, err := NewMatcher(gitserverClient, IndexingExtractor, false, true).CommitsDescribedByPolicy(context.Background(), 50, "r50", policies, now)
 		if err != nil {
@@ -46,7 +47,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 			},
 		}
 
-		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+		runTest(t, mainGitserverClient, policies, map[api.CommitID][]PolicyMatch{
 			// N.B. tag v2.2.2 does not match filter
 			// N.B. tag v1.2.2 does not fall within policy duration
 			"deadbeef04": {PolicyMatch{Name: "v1.2.3", PolicyID: &policyID, PolicyDuration: &testDuration}},
@@ -63,7 +64,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 			},
 		}
 
-		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+		runTest(t, mainGitserverClient, policies, map[api.CommitID][]PolicyMatch{
 			// N.B. branch zw/* does not match this filter
 			// N.B. xy/feature-y does not fall within policy duration
 			"deadbeef07": {PolicyMatch{Name: "xy/feature-x", PolicyID: &policyID, PolicyDuration: &testDuration}},
@@ -81,7 +82,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 			},
 		}
 
-		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+		runTest(t, mainGitserverClient, policies, map[api.CommitID][]PolicyMatch{
 			// N.B. branch zw/* does not match this filter
 			// N.B. xy/feature-y does not fall within policy duration
 			"deadbeef07": {PolicyMatch{Name: "xy/feature-x", PolicyID: &policyID, PolicyDuration: &testDuration}},
@@ -122,7 +123,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 			},
 		}
 
-		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+		runTest(t, mainGitserverClient, policies, map[api.CommitID][]PolicyMatch{
 			"deadbeef01": {
 				PolicyMatch{Name: "develop", PolicyID: &policyID1, PolicyDuration: &testDuration1},
 				PolicyMatch{Name: "develop", PolicyID: &policyID2, PolicyDuration: &testDuration2},
@@ -158,7 +159,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 			},
 		}
 
-		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+		runTest(t, mainGitserverClient, policies, map[api.CommitID][]PolicyMatch{
 			"deadbeef04": {PolicyMatch{Name: "deadbeef04", PolicyID: &policyID, PolicyDuration: &testDuration}},
 		})
 	})
@@ -173,7 +174,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 			},
 		}
 
-		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+		runTest(t, mainGitserverClient, policies, map[api.CommitID][]PolicyMatch{
 			"deadbeef00": {PolicyMatch{Name: "HEAD", PolicyID: &policyID, PolicyDuration: &testDuration}},
 		})
 	})
@@ -188,7 +189,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 			},
 		}
 
-		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+		runTest(t, mainGitserverClient, policies, map[api.CommitID][]PolicyMatch{
 			// N.B. deadbeef05 does not fall within policy duration
 		})
 	})

--- a/internal/codeintel/policies/matcher_indexing_test.go
+++ b/internal/codeintel/policies/matcher_indexing_test.go
@@ -18,6 +18,7 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 	developGitserverClient := testUploadExpirerMockGitserverClient("develop", now)
 
 	runTest := func(t *testing.T, gitserverClient gitserver.Client, policies []policiesshared.ConfigurationPolicy, expectedPolicyMatches map[string][]PolicyMatch) {
+		t.Helper()
 		policyMatches, err := NewMatcher(gitserverClient, IndexingExtractor, false, true).CommitsDescribedByPolicy(context.Background(), 50, "r50", policies, now)
 		if err != nil {
 			t.Fatalf("unexpected error finding matches: %s", err)
@@ -159,6 +160,21 @@ func TestCommitsDescribedByPolicyForIndexing(t *testing.T) {
 
 		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
 			"deadbeef04": {PolicyMatch{Name: "deadbeef04", PolicyID: &policyID, PolicyDuration: &testDuration}},
+		})
+	})
+
+	t.Run("matches HEAD commit policies", func(t *testing.T) {
+		policies := []policiesshared.ConfigurationPolicy{
+			{
+				ID:                policyID,
+				Type:              "GIT_COMMIT",
+				Pattern:           "HEAD",
+				IndexCommitMaxAge: &testDuration,
+			},
+		}
+
+		runTest(t, mainGitserverClient, policies, map[string][]PolicyMatch{
+			"deadbeef00": {PolicyMatch{Name: "HEAD", PolicyID: &policyID, PolicyDuration: &testDuration}},
 		})
 	})
 

--- a/internal/codeintel/policies/service.go
+++ b/internal/codeintel/policies/service.go
@@ -244,7 +244,7 @@ func (s *Service) GetPreviewGitObjectFilter(
 		for _, policyMatch := range policyMatches {
 			gitObjects = append(gitObjects, GitObject{
 				Name:        policyMatch.Name,
-				Rev:         commit,
+				Rev:         string(commit),
 				CommittedAt: policyMatch.CommittedAt,
 			})
 		}
@@ -301,7 +301,7 @@ func (s *Service) getCommitsVisibleToUpload(ctx context.Context, upload shared.U
 func (s *Service) populateMatchingCommits(
 	visibleCommits []string,
 	upload shared.Upload,
-	matchingPolicies map[string][]PolicyMatch,
+	matchingPolicies map[api.CommitID][]PolicyMatch,
 	policies []policiesshared.ConfigurationPolicy,
 	now time.Time,
 ) ([]policiesshared.RetentionPolicyMatchCandidate, map[int]int) {
@@ -314,7 +314,7 @@ func (s *Service) populateMatchingCommits(
 	// and a visible commit, we ensure an entry for that policy is only added for the upload's commit. This makes the logic in checking
 	// the visible commits a bit simpler, as we don't have to check if policy X has already been added for a visible commit in the case
 	// that the upload's commit is not first in the list.
-	if policyMatches, ok := matchingPolicies[upload.Commit]; ok {
+	if policyMatches, ok := matchingPolicies[api.CommitID(upload.Commit)]; ok {
 		for _, policyMatch := range policyMatches {
 			if policyMatch.PolicyDuration == nil || now.Sub(upload.UploadedAt) < *policyMatch.PolicyDuration {
 				policyID := -1
@@ -334,7 +334,7 @@ func (s *Service) populateMatchingCommits(
 		if commit == upload.Commit {
 			continue
 		}
-		if policyMatches, ok := matchingPolicies[commit]; ok {
+		if policyMatches, ok := matchingPolicies[api.CommitID(commit)]; ok {
 			for _, policyMatch := range policyMatches {
 				if policyMatch.PolicyDuration == nil || now.Sub(upload.UploadedAt) < *policyMatch.PolicyDuration {
 					policyID := -1

--- a/internal/codeintel/syntactic_indexing/scheduler_config.go
+++ b/internal/codeintel/syntactic_indexing/scheduler_config.go
@@ -21,7 +21,7 @@ func (c *SchedulerConfig) Load() {
 	repositoryBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_SYNTACTIC_INDEXING_SCHEDULER_REPOSITORY_BATCH_SIZE")
 	policyBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_SYNTACTIC_INDEXING_SCHEDULER_POLICY_BATCH_SIZE")
 
-	c.SchedulerInterval = c.GetInterval(intervalName, "5s", "How frequently to run syntactic indexing scheduling routine.")
+	c.SchedulerInterval = c.GetInterval(intervalName, "2m", "How frequently to run syntactic indexing scheduling routine.")
 	c.RepositoryProcessDelay = c.GetInterval(repositoryProcessDelayName, "24h",
 		"The minimum frequency that the same repository can be considered for syntactic index scheduling.")
 	c.RepositoryBatchSize = c.GetInt(repositoryBatchSizeName, "2500",

--- a/internal/codeintel/syntactic_indexing/scheduler_config.go
+++ b/internal/codeintel/syntactic_indexing/scheduler_config.go
@@ -21,7 +21,7 @@ func (c *SchedulerConfig) Load() {
 	repositoryBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_SYNTACTIC_INDEXING_SCHEDULER_REPOSITORY_BATCH_SIZE")
 	policyBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_SYNTACTIC_INDEXING_SCHEDULER_POLICY_BATCH_SIZE")
 
-	c.SchedulerInterval = c.GetInterval(intervalName, "2m", "How frequently to run syntactic indexing scheduling routine.")
+	c.SchedulerInterval = c.GetInterval(intervalName, "5s", "How frequently to run syntactic indexing scheduling routine.")
 	c.RepositoryProcessDelay = c.GetInterval(repositoryProcessDelayName, "24h",
 		"The minimum frequency that the same repository can be considered for syntactic index scheduling.")
 	c.RepositoryBatchSize = c.GetInt(repositoryBatchSizeName, "2500",

--- a/internal/codeintel/uploads/internal/background/expirer/iface.go
+++ b/internal/codeintel/uploads/internal/background/expirer/iface.go
@@ -14,5 +14,5 @@ type PolicyService interface {
 }
 
 type PolicyMatcher interface {
-	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, repoName api.RepoName, policies []policiesshared.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[string][]policies.PolicyMatch, error)
+	CommitsDescribedByPolicy(ctx context.Context, repositoryID int, repoName api.RepoName, policies []policiesshared.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[api.CommitID][]policies.PolicyMatch, error)
 }

--- a/internal/codeintel/uploads/internal/background/expirer/job_expirer.go
+++ b/internal/codeintel/uploads/internal/background/expirer/job_expirer.go
@@ -143,7 +143,7 @@ func (s *expirer) handleRepository(ctx context.Context, repositoryID int, cfg *C
 
 // buildCommitMap will iterate the complete set of configuration policies that apply to a particular
 // repository and build a map from commits to the policies that apply to them.
-func (s *expirer) buildCommitMap(ctx context.Context, repositoryID int, cfg *Config, now time.Time) (map[string][]policies.PolicyMatch, error) {
+func (s *expirer) buildCommitMap(ctx context.Context, repositoryID int, cfg *Config, now time.Time) (map[api.CommitID][]policies.PolicyMatch, error) {
 	var (
 		t        = true
 		offset   int
@@ -182,7 +182,7 @@ func (s *expirer) buildCommitMap(ctx context.Context, repositoryID int, cfg *Con
 
 func (s *expirer) handleUploads(
 	ctx context.Context,
-	commitMap map[string][]policies.PolicyMatch,
+	commitMap map[api.CommitID][]policies.PolicyMatch,
 	uploads []shared.Upload,
 	cfg *Config,
 	metrics *ExpirationMetrics,
@@ -238,7 +238,7 @@ func (s *expirer) handleUploads(
 
 func (s *expirer) isUploadProtectedByPolicy(
 	ctx context.Context,
-	commitMap map[string][]policies.PolicyMatch,
+	commitMap map[api.CommitID][]policies.PolicyMatch,
 	upload shared.Upload,
 	cfg *Config,
 	metrics *ExpirationMetrics,
@@ -268,7 +268,7 @@ func (s *expirer) isUploadProtectedByPolicy(
 		metrics.NumCommitsScanned.Add(float64(len(commits)))
 
 		for _, commit := range commits {
-			if policyMatches, ok := commitMap[commit]; ok {
+			if policyMatches, ok := commitMap[api.CommitID(commit)]; ok {
 				for _, policyMatch := range policyMatches {
 					if policyMatch.PolicyDuration == nil || now.Sub(upload.UploadedAt) < *policyMatch.PolicyDuration {
 						return true, nil

--- a/internal/codeintel/uploads/internal/background/expirer/job_expirer_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/job_expirer_test.go
@@ -222,7 +222,7 @@ func setupMockUploadService(now time.Time) *storemocks.MockStore {
 }
 
 func testUploadExpirerMockPolicyMatcher() *MockPolicyMatcher {
-	policyMatches := map[int]map[string][]policies.PolicyMatch{
+	policyMatches := map[int]map[api.CommitID][]policies.PolicyMatch{
 		50: {
 			"deadbeef01": {{PolicyDuration: days(1)}}, // 1 = 1
 			"deadbeef02": {{PolicyDuration: days(9)}}, // 9 > 2 (protected)
@@ -254,7 +254,7 @@ func testUploadExpirerMockPolicyMatcher() *MockPolicyMatcher {
 		},
 	}
 
-	commitsDescribedByPolicy := func(ctx context.Context, repositoryID int, repoName api.RepoName, policies []policiesshared.ConfigurationPolicy, now time.Time, _ ...string) (map[string][]policies.PolicyMatch, error) {
+	commitsDescribedByPolicy := func(ctx context.Context, repositoryID int, repoName api.RepoName, policies []policiesshared.ConfigurationPolicy, now time.Time, _ ...string) (map[api.CommitID][]policies.PolicyMatch, error) {
 		return policyMatches[repositoryID], nil
 	}
 

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -31,7 +31,7 @@ type MockPolicyMatcher struct {
 func NewMockPolicyMatcher() *MockPolicyMatcher {
 	return &MockPolicyMatcher{
 		CommitsDescribedByPolicyFunc: &PolicyMatcherCommitsDescribedByPolicyFunc{
-			defaultHook: func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (r0 map[string][]policies.PolicyMatch, r1 error) {
+			defaultHook: func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (r0 map[api.CommitID][]policies.PolicyMatch, r1 error) {
 				return
 			},
 		},
@@ -43,7 +43,7 @@ func NewMockPolicyMatcher() *MockPolicyMatcher {
 func NewStrictMockPolicyMatcher() *MockPolicyMatcher {
 	return &MockPolicyMatcher{
 		CommitsDescribedByPolicyFunc: &PolicyMatcherCommitsDescribedByPolicyFunc{
-			defaultHook: func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
+			defaultHook: func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error) {
 				panic("unexpected invocation of MockPolicyMatcher.CommitsDescribedByPolicy")
 			},
 		},
@@ -65,15 +65,15 @@ func NewMockPolicyMatcherFrom(i PolicyMatcher) *MockPolicyMatcher {
 // CommitsDescribedByPolicy method of the parent MockPolicyMatcher instance
 // is invoked.
 type PolicyMatcherCommitsDescribedByPolicyFunc struct {
-	defaultHook func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)
-	hooks       []func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)
+	defaultHook func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error)
+	hooks       []func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error)
 	history     []PolicyMatcherCommitsDescribedByPolicyFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitsDescribedByPolicy delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockPolicyMatcher) CommitsDescribedByPolicy(v0 context.Context, v1 int, v2 api.RepoName, v3 []shared.ConfigurationPolicy, v4 time.Time, v5 ...string) (map[string][]policies.PolicyMatch, error) {
+func (m *MockPolicyMatcher) CommitsDescribedByPolicy(v0 context.Context, v1 int, v2 api.RepoName, v3 []shared.ConfigurationPolicy, v4 time.Time, v5 ...string) (map[api.CommitID][]policies.PolicyMatch, error) {
 	r0, r1 := m.CommitsDescribedByPolicyFunc.nextHook()(v0, v1, v2, v3, v4, v5...)
 	m.CommitsDescribedByPolicyFunc.appendCall(PolicyMatcherCommitsDescribedByPolicyFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
@@ -82,7 +82,7 @@ func (m *MockPolicyMatcher) CommitsDescribedByPolicy(v0 context.Context, v1 int,
 // SetDefaultHook sets function that is called when the
 // CommitsDescribedByPolicy method of the parent MockPolicyMatcher instance
 // is invoked and the hook queue is empty.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error)) {
 	f.defaultHook = hook
 }
 
@@ -91,7 +91,7 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultHook(hook func(con
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error)) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -99,20 +99,20 @@ func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushHook(hook func(context.C
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultReturn(r0 map[string][]policies.PolicyMatch, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) SetDefaultReturn(r0 map[api.CommitID][]policies.PolicyMatch, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushReturn(r0 map[string][]policies.PolicyMatch, r1 error) {
-	f.PushHook(func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) PushReturn(r0 map[api.CommitID][]policies.PolicyMatch, r1 error) {
+	f.PushHook(func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error) {
 		return r0, r1
 	})
 }
 
-func (f *PolicyMatcherCommitsDescribedByPolicyFunc) nextHook() func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[string][]policies.PolicyMatch, error) {
+func (f *PolicyMatcherCommitsDescribedByPolicyFunc) nextHook() func(context.Context, int, api.RepoName, []shared.ConfigurationPolicy, time.Time, ...string) (map[api.CommitID][]policies.PolicyMatch, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -167,7 +167,7 @@ type PolicyMatcherCommitsDescribedByPolicyFuncCall struct {
 	Arg5 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 map[string][]policies.PolicyMatch
+	Result0 map[api.CommitID][]policies.PolicyMatch
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error


### PR DESCRIPTION
Previously, something like "HEAD" was allowed to be a key in commitmap, which broke other parts of the codebase assuming full-length commit hash.

The issue was spotted in syntactic indexing, where a database constraint was violated:

"ERROR: new row for relation "syntactic_scip_indexing_jobs" violates check constraint "syntactic_scip_indexing_jobs_commit_valid_chars"

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

- New test added

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
