### PR TITLE
repos: use passed in ctx for SystemsInfo

### DIFF
--- a/dev/multitenant/README.md
+++ b/dev/multitenant/README.md
@@ -1,0 +1,4 @@
+# Multi Tenant dev utilities
+
+This directory contains a collection of utilities while we work on multi
+tenancy.

--- a/dev/multitenant/pprof_missing_tenant.sh
+++ b/dev/multitenant/pprof_missing_tenant.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Against a dev environment will collect and merge code paths that are missing
+# tenant
+
+exec go tool pprof -http :10810 http://localhost:{6063,6069,6074,6089,3551,3552}/debug/pprof/missing_tenant

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -114,7 +114,7 @@ func FetchStatusMessages(ctx context.Context, db database.DB, gitserverClient gi
 		diskUsageThreshold = pointers.Ptr(90)
 	}
 
-	si, err := gitserverClient.SystemsInfo(context.Background())
+	si, err := gitserverClient.SystemsInfo(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching gitserver disk info")
 	}


### PR DESCRIPTION
Noticed this when looking at call sites which don't set Tenant.

Test Plan: pprof_missing_tenant.sh no longer reports SystemsInfo
