### PR TITLE
chore: use report-job-failure from sourcegraph/workflows in github actions

### DIFF
--- a/.github/workflows/bazel-test-ownership-check.yml
+++ b/.github/workflows/bazel-test-ownership-check.yml
@@ -82,5 +82,5 @@ jobs:
   report_failure:
     needs: [checks]
     if: ${{ failure() && needs.checks.outputs.below-threshold != 'true' }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
     secrets: inherit

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -30,5 +30,5 @@ jobs:
   report_failure:
     needs: run
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
     secrets: inherit

--- a/.github/workflows/pg-utils.yml
+++ b/.github/workflows/pg-utils.yml
@@ -117,5 +117,5 @@ jobs:
   report_failure:
     needs: [aarch64-darwin, x86_64-darwin, x86_64-linux]
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
     secrets: inherit

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -23,5 +23,5 @@ jobs:
   report_failure:
     needs: check-pr
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
     secrets: inherit

--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -14,5 +14,5 @@ jobs:
   report_failure:
     needs: sync-tracking-issues
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
     secrets: inherit

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -117,5 +117,5 @@ jobs:
   report_failure:
     needs: [aarch64-darwin, x86_64-darwin, x86_64-linux]
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
     secrets: inherit


### PR DESCRIPTION
This PR updates GitHub actions that report failures via sentry to use the workflow from sourcegraph/workflows

Part of DINF-218

[_Created by Sourcegraph batch change `burmudar/github-actions-update-report-failure`._](https://sourcegraph.sourcegraph.com/users/burmudar/batch-changes/github-actions-update-report-failure)